### PR TITLE
Develop quant llama

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ conda activate slora
 # Optional: Install CUDA via conda for a smoother installation experience,
 # but you may need to manually set the Anaconda path variables.
 # conda install cuda -c nvidia/label/cuda-11.8.0
+# set environment variables: export TORCH_CUDA_ARCH_LIST="8.0 8.6"
 pip install torch==2.0.1
 pip install -e .
 ```

--- a/benchmarks/launch_server.py
+++ b/benchmarks/launch_server.py
@@ -24,6 +24,8 @@ if __name__ == "__main__":
     parser.add_argument("--batch-num-adapters", type=int, default=None)
     parser.add_argument("--enable-abort", action="store_true")
     parser.add_argument("--vllm-mem-ratio", type=float, default=0.95)
+
+    parser.add_argument("--gptq", action="store_true")
     args = parser.parse_args()
 
     base_model = BASE_MODEL[args.model_setting]
@@ -71,6 +73,10 @@ if __name__ == "__main__":
         # cmd += " --no-kernel"
         if args.bmm:
             cmd += " --bmm"
+        
+        if args.gptq:
+            cmd += f" --mode gptq"
+        cmd += " --port 19283 --nccl_port 18277"
 
     elif args.backend == "lightllm":
         cmd = f"python -m lightllm.server.api_server" \

--- a/slora/models/exllama_kernels/exllama_kernels/cuda_buffers.cu
+++ b/slora/models/exllama_kernels/exllama_kernels/cuda_buffers.cu
@@ -1,0 +1,71 @@
+// Adapted from turboderp exllama: https://github.com/turboderp/exllama
+
+#define _cuda_buffers_cu
+#include "cuda_buffers.cuh"
+
+CudaBuffers* g_buffers[CUDA_MAX_DEVICES] = {NULL};
+// __constant__ half2 q4_table[16][256];
+// half2 q4_table_host[16][256];
+// bool q4_table_init = false;
+
+CudaBuffers::CudaBuffers
+(
+    int _device,
+    half* _temp_state,
+    half* _temp_dq
+) :
+    device(_device),
+    temp_state(_temp_state),
+    temp_dq(_temp_dq)
+{
+    cudaSetDevice(_device);
+
+    cudaStreamCreate(&alt_stream_1);
+    cudaStreamCreate(&alt_stream_2);
+    cudaStreamCreate(&alt_stream_3);
+    cudaEventCreate(&alt_stream_1_done);
+    cudaEventCreate(&alt_stream_2_done);
+    cudaEventCreate(&alt_stream_3_done);
+}
+
+CudaBuffers::~CudaBuffers()
+{
+    cudaStreamDestroy(alt_stream_1);
+    cudaStreamDestroy(alt_stream_2);
+    cudaStreamDestroy(alt_stream_3);
+    cudaEventDestroy(alt_stream_1_done);
+    cudaEventDestroy(alt_stream_2_done);
+    cudaEventDestroy(alt_stream_3_done);
+}
+
+CudaBuffers* get_buffers(const int device_index)
+{
+    return g_buffers[device_index];
+}
+
+void prepare_buffers_cuda
+(
+    int _device,
+    half* _temp_state,
+    half* _temp_dq
+)
+{
+    CudaBuffers* buffers = new CudaBuffers
+    (
+        _device,
+        _temp_state,
+        _temp_dq
+    );
+
+    g_buffers[_device] = buffers;
+}
+
+void cleanup_buffers_cuda()
+{
+    for (int i = 0; i < CUDA_MAX_DEVICES; i++)
+    {
+        if (!g_buffers[i]) continue;
+        delete g_buffers[i];
+        g_buffers[i] = NULL;
+    }
+}

--- a/slora/models/exllama_kernels/exllama_kernels/cuda_buffers.cuh
+++ b/slora/models/exllama_kernels/exllama_kernels/cuda_buffers.cuh
@@ -1,0 +1,52 @@
+// Adapted from turboderp exllama: https://github.com/turboderp/exllama
+
+#ifndef _cuda_buffers_cuh
+#define _cuda_buffers_cuh
+
+#include <cuda_runtime.h>
+#include <cuda_fp16.h>
+#include <cstdint>
+#include <cstdio>
+
+const int CUDA_MAX_DEVICES = 16;
+
+// #ifndef _cuda_buffers_cu
+// extern __constant__ half2 q4_table[16][256];
+// #endif
+
+class CudaBuffers
+{
+public:
+    int device;
+
+    half* temp_state;           // [max_hidden_rows * intermediate_size]
+    half* temp_dq;              // size of largest quant tensor * 8
+
+    cudaStream_t alt_stream_1;
+    cudaStream_t alt_stream_2;
+    cudaStream_t alt_stream_3;
+    cudaEvent_t alt_stream_1_done;
+    cudaEvent_t alt_stream_2_done;
+    cudaEvent_t alt_stream_3_done;
+
+    CudaBuffers
+    (
+        int _device,
+        half* _temp_state,
+        half* _temp_dq
+    );
+    ~CudaBuffers();
+};
+
+CudaBuffers* get_buffers(const int device_index);
+
+void prepare_buffers_cuda
+(
+    int _device,
+    half* _temp_state,
+    half* _temp_dq
+);
+
+void cleanup_buffers_cuda();
+
+#endif

--- a/slora/models/exllama_kernels/exllama_kernels/cuda_compat.cuh
+++ b/slora/models/exllama_kernels/exllama_kernels/cuda_compat.cuh
@@ -1,0 +1,58 @@
+// Adapted from turboderp exllama: https://github.com/turboderp/exllama
+
+#ifndef _cuda_compat_cuh
+#define _cuda_compat_cuh
+
+// atomicAdd for half types, to support CC < 7.x
+
+__device__ __forceinline__ void atomicAdd_half(half* address, half val)
+{
+    unsigned int * address_as_ui = (unsigned int *) ((char *)address - ((size_t)address & 2));
+    unsigned int old = *address_as_ui;
+    unsigned int assumed;
+
+    do
+    {
+        assumed = old;
+        __half_raw hsum;
+        hsum.x = (size_t)address & 2 ? (old >> 16) : (old & 0xffff);
+        half tmpres = __hadd(hsum, val);
+        hsum = __half_raw(tmpres);
+        old = (size_t)address & 2 ? (old & 0xffff) | (hsum.x << 16) : (old & 0xffff0000) | hsum.x;
+        old = atomicCAS(address_as_ui, assumed, old);
+    }
+    while (assumed != old);
+}
+
+// atomicAdd for half2 types
+
+__device__ __forceinline__ void atomicAdd_half2(half2* address, half2 val)
+{
+    unsigned int* address_as_ui = (unsigned int*)address;
+    unsigned int old = *address_as_ui;
+    unsigned int assumed;
+    do
+    {
+        assumed = old;
+        half2 old_val = *((half2*)&old);
+        half2 new_val = __hadd2(old_val, val);
+        old = atomicCAS(address_as_ui, assumed, *((unsigned int*)&new_val));
+    }
+    while (assumed != old);
+}
+
+//
+
+#if defined(__CUDA_ARCH__)
+#if __CUDA_ARCH__ < 700
+
+__device__ __forceinline__ void atomicAdd(half* address, half val) { atomicAdd_half(address, val); }
+
+#if __CUDA_ARCH__ < 600
+__device__ __forceinline__ void atomicAdd(half2* address, half2 val) { atomicAdd_half2(address, val); }
+#endif
+
+#endif
+#endif
+
+#endif

--- a/slora/models/exllama_kernels/exllama_kernels/cuda_func/column_remap.cu
+++ b/slora/models/exllama_kernels/exllama_kernels/cuda_func/column_remap.cu
@@ -1,0 +1,61 @@
+// Adapted from turboderp exllama: https://github.com/turboderp/exllama
+
+#include "column_remap.cuh"
+#include "../util.cuh"
+
+const int SHUF_BLOCKSIZE_X = 256;
+const int SHUF_BLOCKSIZE_Y = 16;
+
+__global__ void column_remap_kernel
+(
+    const half* __restrict__ x,
+    half* __restrict__ x_new,
+    const int x_width,
+    const int x_height,
+    const uint32_t* x_map
+)
+{
+    int x_column = SHUF_BLOCKSIZE_X * blockIdx.x + threadIdx.x;
+    int x_row = SHUF_BLOCKSIZE_Y * blockIdx.y;
+
+    int x_stride = x_width;
+    int x_idx = x_row * x_stride + x_column;
+
+    int x_row_end = min(x_row + SHUF_BLOCKSIZE_Y, x_height);
+    int x_idx_end = x_row_end * x_stride + x_column;
+
+    int s_column = x_map[x_column];
+    int s_idx = x_row * x_stride + s_column;
+
+    while (x_idx < x_idx_end)
+    {
+        x_new[x_idx] = x[s_idx];
+        x_idx += x_stride;
+        s_idx += x_stride;
+    }
+}
+
+// Remap columns in x to correspond to sequential group index before matmul
+//
+// perform x -> seq_x such that seq_x @ seq_w == x @ w
+
+void column_remap_cuda
+(
+    const half* x,
+    half* x_new,
+    const int x_height,
+    const int x_width,
+    const uint32_t* x_map
+)
+{
+    dim3 threads(SHUF_BLOCKSIZE_X, 1, 1);
+
+    dim3 blocks
+    (
+        (x_width + SHUF_BLOCKSIZE_X - 1) / SHUF_BLOCKSIZE_X,
+        (x_height + SHUF_BLOCKSIZE_Y - 1) / SHUF_BLOCKSIZE_Y,
+        1
+    );
+
+    column_remap_kernel<<<blocks, threads>>>(x, x_new, x_width, x_height, x_map);
+}

--- a/slora/models/exllama_kernels/exllama_kernels/cuda_func/column_remap.cuh
+++ b/slora/models/exllama_kernels/exllama_kernels/cuda_func/column_remap.cuh
@@ -1,0 +1,19 @@
+// Adapted from turboderp exllama: https://github.com/turboderp/exllama
+
+#ifndef _column_remap_cuh
+#define _column_remap_cuh
+
+#include <cuda_runtime.h>
+#include <cuda_fp16.h>
+#include <cstdint>
+
+void column_remap_cuda
+(
+    const half* x,
+    half* x_new,
+    const int x_height,
+    const int x_width,
+    const uint32_t* x_map
+);
+
+#endif

--- a/slora/models/exllama_kernels/exllama_kernels/cuda_func/q4_matmul.cu
+++ b/slora/models/exllama_kernels/exllama_kernels/cuda_func/q4_matmul.cu
@@ -1,0 +1,252 @@
+#include "q4_matmul.cuh"
+#include "column_remap.cuh"
+#include "../util.cuh"
+#include "../matrix.cuh"
+#include "../cuda_compat.cuh"
+#include "../cuda_buffers.cuh"
+
+const int THREADS_X = 32;       // Block size and thread count along columns in w and out
+const int THREADS_Y = 1;        // Block size and thread count along rows in x and out
+
+typedef void (*fp_q4_matmul_kernel)
+(
+    const half*,
+    const uint32_t*,
+    half*,
+    const half*,
+    const uint32_t*,
+    const int,
+    const int,
+    const int,
+    const int,
+    const int,
+    const uint32_t*,
+    bool
+);
+
+template<bool use_half2, bool use_groupsize, bool use_x_map>
+__global__ void q4_matmul_kernel
+(
+    const half* __restrict__ x,
+    const uint32_t* __restrict__ w,
+    half* __restrict__ out,
+    const half* __restrict__ w_scales,
+    const uint32_t* __restrict__ w_zeros,
+    const int height,
+    const int dim,
+    const int width,
+    const int groupsize,
+    const int block_size_z,
+    const uint32_t* __restrict__ x_map,
+    bool no_zero
+)
+{
+    // Start of block
+
+    int x_column = block_size_z * blockIdx.z;
+    int x_column_end = min(dim, block_size_z * (blockIdx.z + 1));
+
+    int w_column = THREADS_X * blockIdx.x + threadIdx.x;
+    int x_row = THREADS_Y * blockIdx.y + threadIdx.y;
+
+    int iterations = (x_column_end - x_column) / 8;
+
+    // Views
+
+    MatrixView_half x_(x, height, dim);
+    MatrixView_half w_scales_(w_scales, dim / groupsize, width);
+    MatrixView_q4_row w_zeros_(w_zeros, dim / groupsize, width);
+    MatrixView_q4_column w_(w, dim, width);
+    MatrixView_half_rw out_(out, height, width);
+
+    // Zero output
+
+    if (!no_zero && blockIdx.z == 0 && (threadIdx.x & 1) == 0)
+    {
+        *((uint32_t*) out_.item_ptr(x_row, w_column)) = 0;
+        __syncthreads();
+    }
+
+    // Loop over part of x row (and w column)
+
+    half2 acc = {};
+    half acc_h = {};
+
+    if constexpr (use_groupsize)
+    {
+        // For quant matrices where groupsize divides BLOCK_SIZE_Z we always start on a group boundary, so this
+        // could be slightly faster
+
+        for (int k = x_column, group = x_column / groupsize; k < x_column + iterations * 8; group++, k += groupsize)
+        {
+            if constexpr (use_half2)
+            {
+                half2 w_scale = w_scales_.item_half2half2(group, w_column);
+                uint32_t w_zero = w_zeros_.item(group, w_column) + 1;
+
+                if constexpr (use_x_map) acc = dot_product_8_x_map(acc, x_, x_row, k, w_, k, w_column, w_scale, w_zero, groupsize / 8, x_map);
+                else                     acc = dot_product_8      (acc, x_, x_row, k, w_, k, w_column, w_scale, w_zero, groupsize / 8);
+            }
+            else
+            {
+                half w_scale = w_scales_.item(group, w_column);
+                uint32_t w_zero = w_zeros_.item(group, w_column) + 1;
+
+                if constexpr (use_x_map) acc_h = dot_product_8_x_map_h(acc_h, x_, x_row, k, w_, k, w_column, w_scale, w_zero, groupsize / 8, x_map);
+                else                     acc_h = dot_product_8_h      (acc_h, x_, x_row, k, w_, k, w_column, w_scale, w_zero, groupsize / 8);
+            }
+        }
+    }
+    else
+    {
+        // Otherwise assume groupsize is a multiple of 8, do 8 columns per iteration and trust the cache
+
+        for (int k = x_column; k < x_column + iterations * 8; k += 8)
+        {
+            if constexpr (use_half2)
+            {
+                int group = k / groupsize;
+                half2 w_scale = w_scales_.item_half2half2(group, w_column);
+                uint32_t w_zero = w_zeros_.item(group, w_column) + 1;
+
+                if constexpr (use_x_map) acc = dot_product_8_x_map(acc, x_, x_row, k, w_, k, w_column, w_scale, w_zero, 1, x_map);
+                else                     acc = dot_product_8      (acc, x_, x_row, k, w_, k, w_column, w_scale, w_zero, 1);
+            }
+            else
+            {
+                int group = k / groupsize;
+                half w_scale = w_scales_.item(group, w_column);
+                uint32_t w_zero = w_zeros_.item(group, w_column) + 1;
+
+                if constexpr (use_x_map) acc_h = dot_product_8_x_map_h(acc_h, x_, x_row, k, w_, k, w_column, w_scale, w_zero, 1, x_map);
+                else                     acc_h = dot_product_8_h      (acc_h, x_, x_row, k, w_, k, w_column, w_scale, w_zero, 1);
+            }
+        }
+    }
+
+    // Add to block result
+
+    if constexpr (use_half2)
+    {
+        half result = __hadd(acc.x, acc.y);
+        atomicAdd(out_.item_ptr(x_row, w_column), result);
+    }
+    else
+    {
+        atomicAdd(out_.item_ptr(x_row, w_column), acc_h);
+    }
+}
+
+fp_q4_matmul_kernel q4_matmul_kernel_pick(ExLlamaTuning* tuningParams, int block_size_z, int groupsize, uint32_t* x_map)
+{
+    // <bool use_half2, bool use_groupsize, bool use_x_map>
+    if (tuningParams->matmul_no_half2) {
+        if (block_size_z % groupsize == 0) {
+            if (x_map) return q4_matmul_kernel<false, true,  true >;
+            else       return q4_matmul_kernel<false, true,  false>;
+        } else {
+            if (x_map) return q4_matmul_kernel<false, false, true >;
+            else       return q4_matmul_kernel<false, false, false>;
+        }
+    } else {
+        if (block_size_z % groupsize == 0)
+        {
+            if (x_map) return q4_matmul_kernel<true,  true,  true >;
+            else       return q4_matmul_kernel<true,  true,  false>;
+        } else {
+            if (x_map) return q4_matmul_kernel<true,  false, true >;
+            else       return q4_matmul_kernel<true,  false, false>;
+        }
+    }
+};
+
+// Compute y = x @ w
+
+void q4_matmul_cuda
+(
+    ExLlamaTuning* tuningParams,
+    const half* x,
+    const int x_height,
+    const Q4Matrix* w,
+    half* out,
+    bool no_zero,
+    cudaStream_t alt_stream
+)
+{
+    int height = x_height;
+    int dim = w->height;
+    int width = w->width;
+
+    cudaSetDevice(w->device);
+
+    uint32_t* x_map = w->cuda_x_map;
+    const half* x_mapped = x;
+    if (x_map && !tuningParams->matmul_fused_remap && !alt_stream)
+    {
+        CudaBuffers* buffers = get_buffers(w->device);
+        column_remap_cuda(x, buffers->temp_state, x_height, dim, w->cuda_x_map);
+        x_mapped = buffers->temp_state;
+        x_map = NULL;
+    }
+
+    int block_size_z;
+    if (w->width == 4096) block_size_z = 384;           // 7B
+    else if (w->width == 11008) block_size_z = 256;
+    else if (w->width == 5120) block_size_z = 384;      // 13B
+    else if (w->width == 13824) block_size_z = 256;
+    else if (w->width == 6656) block_size_z = 256;      // 33B
+    else if (w->width == 17920) block_size_z = 128;
+    else block_size_z = 256;
+
+    //if (!no_zero) cudaMemsetAsync(out, 0, x_height * w->width * sizeof(half));
+
+    dim3 threads(THREADS_X, THREADS_Y, 1);
+
+    dim3 blocks
+    (
+        (width + threads.x - 1) / threads.x,
+        (height + threads.y - 1) / threads.y,
+        (dim + block_size_z - 1) / block_size_z
+    );
+
+    fp_q4_matmul_kernel kernel = q4_matmul_kernel_pick(tuningParams, block_size_z, w->groupsize, x_map);
+
+    kernel<<<blocks, threads, 0, alt_stream>>> (x_mapped, w->cuda_qweight, out, w->cuda_scales, w->cuda_qzeros, height, dim, width, w->groupsize, block_size_z, x_map, no_zero);
+}
+
+void q4_matmul_recons_cuda
+(
+    ExLlamaTuning* tuningParams,
+    const half* x,
+    const int x_height,
+    Q4Matrix* w,
+    half* out,
+    const cublasHandle_t handle,
+    bool no_zero
+)
+{
+    int height = x_height;
+    int dim = w->height;
+    int width = w->width;
+
+    cudaSetDevice(w->device);
+    CudaBuffers* buffers = get_buffers(w->device);
+
+    const half* x_mapped = x;
+    if (w->cuda_x_map)
+    {
+        column_remap_cuda(x, buffers->temp_state, x_height, dim, w->cuda_x_map);
+        x_mapped = buffers->temp_state;
+    }
+
+    w->reconstruct(buffers->temp_dq);
+
+    const half alpha = __float2half(1.0f);
+    const half beta = no_zero ? __float2half(1.0f) : __float2half(0.0f);
+    cublasHgemm(handle, CUBLAS_OP_N, CUBLAS_OP_N, width, height, dim, &alpha, buffers->temp_dq, width, x_mapped, dim, &beta, out, width);
+
+//     const float alpha = 1.0f;
+//     const float beta = no_zero ? 1.0f : 0.0f;
+//     cublasSgemmEx(handle, CUBLAS_OP_N, CUBLAS_OP_N, width, height, dim, &alpha, buffers->temp_dq, CUDA_R_16F, width,
+//                 x_mapped, CUDA_R_16F, dim, &beta, out, CUDA_R_16F, width);
+}

--- a/slora/models/exllama_kernels/exllama_kernels/cuda_func/q4_matmul.cuh
+++ b/slora/models/exllama_kernels/exllama_kernels/cuda_func/q4_matmul.cuh
@@ -1,0 +1,37 @@
+// Adapted from turboderp exllama: https://github.com/turboderp/exllama
+
+#ifndef _q4_matmul_cuh
+#define _q4_matmul_cuh
+
+#include <cuda_runtime.h>
+#include <cuda_fp16.h>
+#include <cstdint>
+#include <cstdio>
+#include <ATen/cuda/CUDAContext.h>
+
+#include "q4_matrix.cuh"
+#include "../tuning.h"
+
+void q4_matmul_cuda
+(
+    ExLlamaTuning* tuningParams,
+    const half* x,
+    const int x_height,
+    const Q4Matrix* w,
+    half* out,
+    bool no_zero = false,
+    cudaStream_t alt_stream = NULL
+);
+
+void q4_matmul_recons_cuda
+(
+    ExLlamaTuning* tuningParams,
+    const half* x,
+    const int x_height,
+    Q4Matrix* w,
+    half* out,
+    const cublasHandle_t handle,
+    bool no_zero = false
+);
+
+#endif

--- a/slora/models/exllama_kernels/exllama_kernels/cuda_func/q4_matrix.cu
+++ b/slora/models/exllama_kernels/exllama_kernels/cuda_func/q4_matrix.cu
@@ -1,0 +1,217 @@
+// Adapted from turboderp exllama: https://github.com/turboderp/exllama
+
+#include "q4_matrix.cuh"
+#include <vector>
+#include "../util.cuh"
+#include "../matrix.cuh"
+
+using namespace std;
+
+const int UNSHUF_BLOCKSIZE_X = 64;
+
+const int RECONS_THREADS_X = 64;      // Block size and thread count along columns in out, each thread converts 1 column
+const int RECONS_THREADS_Y = 1;       // Block size and thread count along rows in x and out, each thread converts 8 rows
+
+vector<Q4Matrix*> g_q4_matrices;
+
+void g_q4_keep_matrix(Q4Matrix* m)
+{
+    g_q4_matrices.push_back(m);
+}
+
+void g_q4_free_matrices()
+{
+    for (const auto& m : g_q4_matrices) delete m;
+    g_q4_matrices.clear();
+}
+
+Q4Matrix::Q4Matrix
+(
+    const int _height,
+    const int _width,
+    const int _groups,
+
+    uint32_t* _qweight,
+    uint32_t* _qzeros,
+    half* _scales,
+    uint32_t* _g_idx,
+
+    const int _device
+) :
+    height(_height),
+    width(_width),
+    groups(_groups),
+    device(_device)
+{
+    cudaSetDevice(device);
+
+    cuda_qweight = _qweight;
+    cuda_qzeros = _qzeros;
+    cuda_scales = _scales;
+
+    groupsize = height / groups;
+
+    if (_g_idx) make_sequential(_g_idx);
+}
+
+Q4Matrix::~Q4Matrix()
+{
+}
+
+// Make sequential
+
+__global__ void make_sequential_kernel
+(
+    const uint32_t* __restrict__ w,
+    uint32_t* __restrict__ w_new,
+    const uint32_t* __restrict__ x_map,
+    const int w_height,
+    const int w_width
+)
+{
+    const uint64_t* w2 = (uint64_t*) w;
+    uint64_t* w_new2 = (uint64_t*) w_new;
+    int w2_stride = w_width >> 1;
+
+    int w2_column = UNSHUF_BLOCKSIZE_X * blockIdx.x + threadIdx.x;
+    int w_new2_row = blockIdx.y;
+
+    int x_map_idx = w_new2_row << 3;
+
+    uint64_t dst = 0;
+
+    #pragma unroll
+    for (int i = 0; i < 8; i++)
+    {
+        int source_row = x_map[x_map_idx++];
+
+        int w2_row = source_row >> 3;
+        int w2_subrow = source_row & 0x07;
+        int w2_row_shift = w2_subrow << 2;
+        int wnew2_row_shift = i << 2;
+
+        uint64_t src = w2[w2_row * w2_stride + w2_column];
+        src >>= w2_row_shift;
+        src &= 0x0000000f0000000f;
+        src <<= wnew2_row_shift;
+        dst |= src;
+    }
+
+    w_new2[w_new2_row * w2_stride + w2_column] = dst;
+}
+
+void Q4Matrix::make_sequential(const uint32_t* cpu_g_idx)
+{
+    uint32_t* cuda_new_qweight = NULL;
+    cudaMalloc(&cuda_new_qweight, height / 8 * width * sizeof(uint32_t));
+    cudaMalloc(&cuda_x_map, height * sizeof(uint32_t));  // TODO: Should probably be allocated in PyTorch
+
+    uint32_t* cpu_g_idx_map = (uint32_t*) calloc(groups, sizeof(uint32_t));
+    uint32_t* cpu_x_map = (uint32_t*) malloc(height * sizeof(uint32_t));
+    uint32_t* cpu_x_map_inv = (uint32_t*) malloc(height * sizeof(uint32_t));
+
+    // Group histogram
+
+    for (int i = 0; i < height; i++) cpu_g_idx_map[cpu_g_idx[i]]++;
+
+    // Group map
+
+    for (int i = 0, acc = 0; i < groups; i++)
+    {
+        short tmp = cpu_g_idx_map[i];
+        cpu_g_idx_map[i] = acc;
+        acc += tmp;
+    }
+
+    // X map (inverse)
+
+    for (int row = 0; row < height; row++)
+    {
+        uint32_t target_group = cpu_g_idx[row];
+        uint32_t target_row = cpu_g_idx_map[target_group];
+        cpu_g_idx_map[target_group]++;
+        cpu_x_map_inv[row] = target_row;
+    }
+
+    // X map
+
+    for (int row = 0; row < height; row++) cpu_x_map[cpu_x_map_inv[row]] = row;
+
+    // Move to CUDA
+
+    cudaMemcpyAsync(cuda_x_map, cpu_x_map, height * sizeof(uint32_t), cudaMemcpyHostToDevice);
+
+    // Rearrange rows in w
+
+    dim3 threads(UNSHUF_BLOCKSIZE_X, 1, 1);
+    dim3 blocks(width / UNSHUF_BLOCKSIZE_X / 2, height / 8, 1);
+
+    make_sequential_kernel<<<blocks, threads>>>(cuda_qweight, cuda_new_qweight, cuda_x_map, height / 8, width);
+
+    // Replace qweights
+
+    cudaMemcpyAsync(cuda_qweight, cuda_new_qweight, height / 8 * width * sizeof(uint32_t), cudaMemcpyDeviceToDevice);
+
+    // Cleanup
+
+    cudaDeviceSynchronize();
+    cudaFree(cuda_new_qweight);
+    free(cpu_g_idx_map);
+    free(cpu_x_map);
+    free(cpu_x_map_inv);
+}
+
+__global__ void reconstruct_kernel
+(
+    const uint32_t* __restrict__ w,
+    half* __restrict__ out,  // (y)
+    const half* __restrict__ w_scales,
+    const uint32_t* __restrict__ w_zeros,
+    const int height,
+    const int width,
+    const int groupsize
+)
+{
+    // Start of block
+
+    int column = RECONS_THREADS_X * blockIdx.x + threadIdx.x;
+    int row = (RECONS_THREADS_Y * blockIdx.y + threadIdx.y) * 8;
+
+    // Views
+
+    MatrixView_q4_column w_(w, height, width);
+    MatrixView_half_rw out_(out, height, width);
+    MatrixView_half w_scales_(w_scales, height / groupsize, width);
+    MatrixView_q4_row w_zeros_(w_zeros, height / groupsize, width);
+
+    // Groupsize version
+
+    int group = row / groupsize;
+
+    half w_scale = w_scales_.item(group, column);
+    uint32_t w_zero = w_zeros_.item(group, column) + 1;
+
+    uint32_t w_read = w_.item_uint32_t(row, column);
+    half* out_ptr = out_.item_ptr(row, column);
+
+    #pragma unroll
+    for (int s = 0; s < 32; s += 4)
+    {
+        half w_item = __hmul(__int2half_rn((int)((w_read >> s) & 0x0f) - w_zero), w_scale);
+        *out_ptr = w_item; out_ptr += out_.width;
+    }
+}
+
+void Q4Matrix::reconstruct(half* out)
+{
+    dim3 threads(RECONS_THREADS_X, RECONS_THREADS_Y, 1);
+
+    dim3 blocks
+    (
+        (width + threads.x - 1) / threads.x,
+        (height / 8 + threads.y - 1) / threads.y,
+        1
+    );
+
+    reconstruct_kernel<<<blocks, threads>>>(cuda_qweight, out, cuda_scales, cuda_qzeros, height / 8, width, groupsize);
+}

--- a/slora/models/exllama_kernels/exllama_kernels/cuda_func/q4_matrix.cuh
+++ b/slora/models/exllama_kernels/exllama_kernels/cuda_func/q4_matrix.cuh
@@ -1,0 +1,53 @@
+// Adapted from turboderp exllama: https://github.com/turboderp/exllama
+
+#ifndef _q4_matrix_cuh
+#define _q4_matrix_cuh
+
+#include <cuda_runtime.h>
+#include <cuda_fp16.h>
+#include <cstdint>
+
+class Q4Matrix
+{
+public:
+
+    int device;
+
+    int height;
+    int width;
+    int groups;
+    int groupsize;
+
+    uint32_t* cuda_qweight = NULL;
+    uint32_t* cuda_qzeros = NULL;
+    half* cuda_scales = NULL;
+    uint32_t* cuda_x_map = NULL;
+
+    Q4Matrix
+    (
+        const int _height,
+        const int _width,
+        const int _groups,
+
+        uint32_t* _qweight,
+        uint32_t* _qzeros,
+        half* _scales,
+        uint32_t* _g_idx,
+
+        const int _device
+    );
+
+    ~Q4Matrix();
+
+    void reconstruct(half* out);
+
+private:
+
+    void make_sequential(const uint32_t* cpu_g_idx);
+
+};
+
+void g_q4_keep_matrix(Q4Matrix* m);
+void g_q4_free_matrices();
+
+#endif

--- a/slora/models/exllama_kernels/exllama_kernels/exllama_ext.cpp
+++ b/slora/models/exllama_kernels/exllama_kernels/exllama_ext.cpp
@@ -1,0 +1,249 @@
+// Adapted from turboderp exllama: https://github.com/turboderp/exllama
+
+#include <torch/extension.h>
+#include <c10/cuda/CUDAGuard.h>
+#include <ATen/cuda/CUDAContext.h>
+#include <cuda_runtime.h>
+#include <cuda_fp16.h>
+#include <cstdint>
+#include <cstdio>
+#include "util.cuh"
+#include "tuning.h"
+#include "cuda_buffers.cuh"
+#include "cuda_func/q4_matrix.cuh"
+#include "cuda_func/q4_matmul.cuh"
+#include "cuda_func/column_remap.cuh"
+
+// Check CUDA return code. We don't want to include Torch headers in the .cu files because parsing them adds almost a
+// minute to the compile time on a 12900K. Also passing exceptions back to Python is super tricky, so in place of
+// exceptions, CUDA functions return with a cudaError_t which we can parse and dump to the console.
+
+void check_cuda(cudaError_t ret)
+{
+    switch (ret)
+    {
+        case cudaSuccess:
+            break;
+
+        case cudaUnspecified:
+            printf(" **** Unspecified error\n");
+            TORCH_CHECK(false, "CUDA error");
+            break;
+
+        default:
+            printf(" **** CUDA error\n"); \
+            printf(" **** %s\n", cudaGetErrorString(ret)); \
+            TORCH_CHECK(false, "CUDA error"); \
+            break;
+    }
+}
+
+// Some decluttering macros
+
+#define STRINGIFY_(__x) #__x
+#define STRINGIFY(__x) STRINGIFY_(__x)
+#define TORCH_CHECK_DTYPE(__x, __dtype) TORCH_CHECK((__x).dtype() == torch::__dtype, #__x " is incorrect datatype, must be " #__dtype)
+#define TORCH_CHECK_DTYPE_OPT(__x, __dtype) TORCH_CHECK((__x).device().is_meta() || (__x).dtype() == torch::__dtype, #__x " is incorrect datatype, must be " #__dtype)
+#define TORCH_CHECK_SHAPES(__x, __dim_x, __y, __dim_y, __scale_y) TORCH_CHECK((__x).size(__dim_x) == (__y).size(__dim_y) * __scale_y, #__x " and " #__y " have incompatible shapes")
+#define TORCH_CHECK_SHAPES_OPT(__x, __dim_x, __y, __dim_y, __scale_y) TORCH_CHECK((__x).device().is_meta() || (__x).size(__dim_x) == (__y).size(__dim_y) * __scale_y, #__x " and " #__y " have incompatible shapes")
+#define TORCH_CHECK_SHAPE_MOD(__x, __dim_x, __mod) TORCH_CHECK((__x).size(__dim_x) % __mod == 0, #__x ".shape[" STRINGIFY(__dim_x) "] must be a multiple of " STRINGIFY(__mod))
+
+#define TORCH_CHECK_DEVICE_INDEX(__index) \
+do { \
+    TORCH_CHECK(__index >= 0, "no device index"); \
+    TORCH_CHECK(__index < CUDA_MAX_DEVICES, "invalid device index"); \
+} while(0)
+
+#define TORCH_CHECK_QUANT(__w, __w_scales, __w_zeros, __seq_g_idx, __x_map) \
+do { \
+    TORCH_CHECK_DTYPE(__w, kInt); \
+    TORCH_CHECK_DTYPE(__w_scales, kHalf); \
+    TORCH_CHECK_DTYPE(__w_zeros, kInt); \
+    TORCH_CHECK_DTYPE_OPT(__seq_g_idx, kShort); \
+    TORCH_CHECK_DTYPE_OPT(__x_map, kInt); \
+    TORCH_CHECK_SHAPES_OPT(__seq_g_idx, 0, __w, 0, 2 * 8); \
+    TORCH_CHECK_SHAPES_OPT(__x_map, 0, __w, 0, 8); \
+} while(0)
+
+int get_groupsize(torch::Tensor w, torch::Tensor w_zeros)
+{
+    int groupsize = w.size(0) * 8 / w_zeros.size(0);
+    TORCH_CHECK(groupsize * w_zeros.size(0) == w.size(0) * 8, "w.shape[-2] must be a multiple of zeros.shape[-2]")
+    return groupsize;
+}
+
+
+// Tuning parameters
+
+ExLlamaTuning tuningParams;
+
+void set_tuning_params
+(
+    int matmul_recons_thd,
+    bool matmul_fused_remap,
+    bool matmul_no_half2
+)
+{
+    tuningParams.matmul_recons_thd = matmul_recons_thd;
+    tuningParams.matmul_fused_remap = matmul_fused_remap;
+    tuningParams.matmul_no_half2 = matmul_no_half2;
+}
+
+
+// Release all unmanaged objects allocated by the extension
+
+void cleanup()
+{
+    cleanup_buffers_cuda();
+    g_q4_free_matrices();
+}
+
+
+// Prepare buffers for forward pass
+
+void prepare_buffers
+(
+    torch::Device device,
+    torch::Tensor temp_state,
+    torch::Tensor temp_dq
+)
+{
+    int device_index = device.index();
+    TORCH_CHECK_DEVICE_INDEX(device_index);
+    const at::cuda::OptionalCUDAGuard device_guard(device);
+
+    prepare_buffers_cuda
+    (
+        device_index,
+        (half*) temp_state.data_ptr(),
+        (half*) temp_dq.data_ptr()
+    );
+}
+
+
+// Create Q4Matrix, return handle
+
+uintptr_t make_q4
+(
+    torch::Tensor qweight,
+    torch::Tensor qzeros,
+    torch::Tensor scales,
+    torch::Tensor g_idx,
+    int device
+)
+{
+    TORCH_CHECK_DTYPE(qweight, kInt);
+    TORCH_CHECK_DTYPE(qzeros, kInt);
+    TORCH_CHECK_DTYPE(scales, kHalf);
+    TORCH_CHECK_DTYPE_OPT(g_idx, kInt);
+    TORCH_CHECK_SHAPES(qweight, 1, qzeros, 1, 8);
+    TORCH_CHECK_SHAPES(scales, 1, qweight, 1, 1);
+    TORCH_CHECK_SHAPES(qzeros, 0, scales, 0, 1);
+
+    int width = qweight.size(1);
+    int height = qweight.size(0) * 8;
+    int groups = qzeros.size(0);
+
+    Q4Matrix* m = new Q4Matrix
+    (
+        height,
+        width,
+        groups,
+
+        (uint32_t*) qweight.data_ptr(),
+        (uint32_t*) qzeros.data_ptr(),
+        (half*) scales.data_ptr(),
+        g_idx.device().is_meta() ? NULL : (uint32_t*) g_idx.data_ptr(),
+
+        device
+    );
+
+    g_q4_keep_matrix(m);
+    return reinterpret_cast<uintptr_t> (m);
+}
+
+
+// Matmul half @ quant -> half
+
+void q4_matmul
+(
+    torch::Tensor x,
+    uintptr_t w,
+    torch::Tensor out
+)
+{
+    Q4Matrix* wm = reinterpret_cast<Q4Matrix*> (w);
+
+    TORCH_CHECK_DTYPE(x, kHalf);
+    TORCH_CHECK_DTYPE(out, kHalf);
+    TORCH_CHECK_SHAPES(x, 0, out, 0, 1);
+    TORCH_CHECK(wm->height == x.size(-1), "x and w have incompatible shapes")
+
+    const at::cuda::OptionalCUDAGuard device_guard(device_of(x));
+
+    int x_height = x.size(0);
+
+    if (tuningParams.matmul_recons_thd == 0 || x_height < tuningParams.matmul_recons_thd)
+    {
+        q4_matmul_cuda
+        (
+            &tuningParams,
+            (half*) x.data_ptr(),
+            x_height,
+            wm,
+            (half*) out.data_ptr()
+        );
+    }
+    else
+    {
+        q4_matmul_recons_cuda
+        (
+            &tuningParams,
+            (half*) x.data_ptr(),
+            x_height,
+            wm,
+            (half*) out.data_ptr(),
+            at::cuda::getCurrentCUDABlasHandle()
+        );
+    }
+}
+
+
+// Remap columns in half tensor
+
+void column_remap
+(
+    torch::Tensor x,
+    torch::Tensor x_new,
+    torch::Tensor x_map
+)
+{
+    TORCH_CHECK_DTYPE(x, kHalf);
+    TORCH_CHECK_DTYPE(x_new, kHalf);
+    TORCH_CHECK_DTYPE(x_map, kInt);
+    TORCH_CHECK_SHAPES(x_map, 0, x, 1, 1);
+
+    int height = x.size(0);
+    int width = x.size(1);
+
+    const at::cuda::OptionalCUDAGuard device_guard(device_of(x));
+
+    column_remap_cuda
+    (
+        (half*) x.data_ptr(),
+        (half*) x_new.data_ptr(),
+        height,
+        width,
+        (uint32_t*) x_map.data_ptr()
+    );
+}
+
+
+PYBIND11_MODULE(TORCH_EXTENSION_NAME, m)
+{
+    m.def("set_tuning_params", &set_tuning_params, "set_tuning_params");
+    m.def("prepare_buffers", &prepare_buffers, "prepare_buffers");
+    m.def("cleanup", &cleanup, "cleanup");
+    m.def("make_q4", &make_q4, "make_q4");
+    m.def("q4_matmul", &q4_matmul, "q4_matmul");
+}

--- a/slora/models/exllama_kernels/exllama_kernels/matrix.cuh
+++ b/slora/models/exllama_kernels/exllama_kernels/matrix.cuh
@@ -1,0 +1,294 @@
+// Adapted from turboderp exllama: https://github.com/turboderp/exllama
+
+#ifndef _matrix_cuh
+#define _matrix_cuh
+
+#include <cuda_runtime.h>
+#include <cuda_fp16.h>
+
+class MatrixView_half
+{
+public:
+    const half* data;
+    const int height;
+    const int width;
+
+    __device__ __forceinline__ MatrixView_half(const half* data, const int height, const int width)
+        : data(data), height(height), width(width)
+    { }
+
+    __device__ __forceinline__ half item(int row, int column) const { return data[row * width + column]; }
+    __device__ __forceinline__ half2 item_half2(int row, int column) const { return ((half2*)data)[(row * width + column) / 2]; }
+    __device__ __forceinline__ half2 item_half2half2(int row, int column) const { return __half2half2(data[row * width + column]); }
+    __device__ __forceinline__ const half* item_ptr(int row, int column) const { return &data[row * width + column]; }
+};
+
+class MatrixView_half_rw
+{
+public:
+    half* data;
+    const int height;
+    const int width;
+
+    __device__ __forceinline__ MatrixView_half_rw(half* data, const int height, const int width)
+        : data(data), height(height), width(width)
+    { }
+
+    __device__ __forceinline__ half item(int row, int column) const { return data[row * width + column]; }
+    __device__ __forceinline__ half2 item_half2(int row, int column) const { return ((half2*)data)[(row * width + column) / 2]; }
+    __device__ __forceinline__ half* item_ptr(int row, int column) { return &data[row * width + column]; }
+    __device__ __forceinline__ void set(int row, int column, half value) { data[row * width + column] = value; }
+    __device__ __forceinline__ void set_half2(int row, int column, half2 value) { ((half2*)data)[(row * width + column) / 2] = value; }
+};
+
+class MatrixView_q4_row
+{
+public:
+    const uint32_t* data;
+    const int height;
+    const int width;
+
+    __device__ __forceinline__ MatrixView_q4_row(const uint32_t* data, const int height, const int width)
+        : data(data), height(height), width(width)
+    { }
+
+    __device__ __forceinline__ int item(int row, int column) const
+    {
+        int shift = (column & 0x07) * 4;
+        return (data[row * width / 8 + column / 8] >> shift) & 0x0f;
+    }
+};
+
+class MatrixView_q4_column
+{
+public:
+    const uint32_t* data;
+    const int height;
+    const int width;
+
+    __device__ __forceinline__ MatrixView_q4_column(const uint32_t* data, const int height, const int width)
+        : data(data), height(height), width(width)
+    { }
+
+    __device__ __forceinline__ int item(int row, int column) const
+    {
+        int shift = (row & 0x07) * 4;
+        return (data[row / 8 * width + column] >> shift) & 0x0f;
+    }
+
+    __device__ __forceinline__ uint32_t item_uint32_t(int row, int column) { return data[row / 8 * width + column]; }
+    __device__ __forceinline__ const uint32_t* item_uint32_ptr(int row, int column) { return &data[row / 8 * width + column]; }
+};
+
+// TODO: Rewrite all these dot product functions using functors or something, move to q4_matmul.cu
+
+// Accumulated dot product of 8-element row vectors in h and quantized column vectors in v, constant zero/scale
+
+__device__ __forceinline__ half2 dot_product_8
+(
+    const half2 acc,
+    MatrixView_half& h_,
+    const int h_row,
+    const int h_column,                 // divisible by 8
+    MatrixView_q4_column& v_,
+    const int v_row,                    // divisible by 8
+    const int v_column,
+    const half2 v_scale_2,
+    const uint32_t v_zero,              // + 1 (!!)
+    const int count
+)
+{
+    const half2* h_ptr = (const half2*) h_.item_ptr(h_row, h_column);
+    const uint32_t* v_ptr = (const uint32_t*) v_.item_uint32_ptr(v_row, v_column);
+    half2 result = acc;
+
+    for (int i = 0; i < count; i++)
+    {
+        uint32_t v_read = *v_ptr; v_ptr += v_.width;
+
+        half v_0 = __int2half_rn((int)((v_read      ) & 0x0f) - v_zero);
+        half v_1 = __int2half_rn((int)((v_read >>  4) & 0x0f) - v_zero);
+        half v_2 = __int2half_rn((int)((v_read >>  8) & 0x0f) - v_zero);
+        half v_3 = __int2half_rn((int)((v_read >> 12) & 0x0f) - v_zero);
+        half v_4 = __int2half_rn((int)((v_read >> 16) & 0x0f) - v_zero);
+        half v_5 = __int2half_rn((int)((v_read >> 20) & 0x0f) - v_zero);
+        half v_6 = __int2half_rn((int)((v_read >> 24) & 0x0f) - v_zero);
+        half v_7 = __int2half_rn((int)((v_read >> 28)       ) - v_zero);
+
+        half2 v_01 = __halves2half2(v_0, v_1);
+        half2 v_23 = __halves2half2(v_2, v_3);
+        half2 v_45 = __halves2half2(v_4, v_5);
+        half2 v_67 = __halves2half2(v_6, v_7);
+
+//         half2 v_01 = q4_table[v_zero - 1][(v_read      ) & 0xff]; // (constant memory is too slow apparently)
+//         half2 v_23 = q4_table[v_zero - 1][(v_read >>  8) & 0xff];
+//         half2 v_45 = q4_table[v_zero - 1][(v_read >> 16) & 0xff];
+//         half2 v_67 = q4_table[v_zero - 1][(v_read >> 24)       ];
+
+        half2 tmp = __hmul2(*h_ptr++, v_01);
+        tmp = __hfma2(*h_ptr++, v_23, tmp);
+        tmp = __hfma2(*h_ptr++, v_45, tmp);
+        tmp = __hfma2(*h_ptr++, v_67, tmp);
+        result = __hfma2(v_scale_2, tmp, result);
+    }
+
+    return result;
+}
+
+__device__ __forceinline__ half dot_product_8_h
+(
+    const half acc,
+    MatrixView_half& h_,
+    const int h_row,
+    const int h_column,                 // divisible by 8
+    MatrixView_q4_column& v_,
+    const int v_row,                    // divisible by 8
+    const int v_column,
+    const half v_scale,
+    const uint32_t v_zero,              // + 1 (!!)
+    const int count
+)
+{
+    const half* h_ptr = h_.item_ptr(h_row, h_column);
+    const uint32_t* v_ptr = (const uint32_t*) v_.item_uint32_ptr(v_row, v_column);
+    half result = acc;
+
+    for (int i = 0; i < count; i++)
+    {
+        uint32_t v_read = *v_ptr; v_ptr += v_.width;
+
+        half v_0 = __int2half_rn((int)((v_read      ) & 0x0f) - v_zero);
+        half v_1 = __int2half_rn((int)((v_read >>  4) & 0x0f) - v_zero);
+        half v_2 = __int2half_rn((int)((v_read >>  8) & 0x0f) - v_zero);
+        half v_3 = __int2half_rn((int)((v_read >> 12) & 0x0f) - v_zero);
+        half v_4 = __int2half_rn((int)((v_read >> 16) & 0x0f) - v_zero);
+        half v_5 = __int2half_rn((int)((v_read >> 20) & 0x0f) - v_zero);
+        half v_6 = __int2half_rn((int)((v_read >> 24) & 0x0f) - v_zero);
+        half v_7 = __int2half_rn((int)((v_read >> 28)       ) - v_zero);
+
+        half tmp = __hmul(*h_ptr++, v_0);
+        tmp = __hfma(*h_ptr++, v_1, tmp);
+        tmp = __hfma(*h_ptr++, v_2, tmp);
+        tmp = __hfma(*h_ptr++, v_3, tmp);
+        tmp = __hfma(*h_ptr++, v_4, tmp);
+        tmp = __hfma(*h_ptr++, v_5, tmp);
+        tmp = __hfma(*h_ptr++, v_6, tmp);
+        tmp = __hfma(*h_ptr++, v_7, tmp);
+        result = __hfma(v_scale, tmp, result);
+    }
+
+    return result;
+}
+
+// Accumulated dot product of 8-element row vectors in h and quantized column vectors in v, constant zero/scale, with x_map
+
+__device__ __forceinline__ half2 dot_product_8_x_map
+(
+    const half2 acc,
+    MatrixView_half& h_,
+    const int h_row,
+    const int h_column,                 // divisible by 8
+    MatrixView_q4_column& v_,
+    const int v_row,                    // divisible by 8
+    const int v_column,
+    const half2 v_scale_2,
+    const uint32_t v_zero,              // + 1 (!!)
+    const int count,
+    const uint32_t* x_map
+)
+{
+    const half* h_ptr = h_.item_ptr(h_row, 0);
+    const uint32_t* x_map_ptr = x_map + h_column;
+    const uint32_t* v_ptr = (const uint32_t*) v_.item_uint32_ptr(v_row, v_column);
+    half2 result = acc;
+
+    for (int i = 0; i < count; i++)
+    {
+        uint32_t v_read = *v_ptr; v_ptr += v_.width;
+
+        half v_0 = __int2half_rn((int)((v_read      ) & 0x0f) - v_zero);
+        half v_1 = __int2half_rn((int)((v_read >>  4) & 0x0f) - v_zero);
+        half v_2 = __int2half_rn((int)((v_read >>  8) & 0x0f) - v_zero);
+        half v_3 = __int2half_rn((int)((v_read >> 12) & 0x0f) - v_zero);
+        half v_4 = __int2half_rn((int)((v_read >> 16) & 0x0f) - v_zero);
+        half v_5 = __int2half_rn((int)((v_read >> 20) & 0x0f) - v_zero);
+        half v_6 = __int2half_rn((int)((v_read >> 24) & 0x0f) - v_zero);
+        half v_7 = __int2half_rn((int)((v_read >> 28)       ) - v_zero);
+
+        half2 v_01 = __halves2half2(v_0, v_1);
+        half2 v_23 = __halves2half2(v_2, v_3);
+        half2 v_45 = __halves2half2(v_4, v_5);
+        half2 v_67 = __halves2half2(v_6, v_7);
+
+        half h_0 = h_ptr[*x_map_ptr++];
+        half h_1 = h_ptr[*x_map_ptr++];
+        half h_2 = h_ptr[*x_map_ptr++];
+        half h_3 = h_ptr[*x_map_ptr++];
+        half h_4 = h_ptr[*x_map_ptr++];
+        half h_5 = h_ptr[*x_map_ptr++];
+        half h_6 = h_ptr[*x_map_ptr++];
+        half h_7 = h_ptr[*x_map_ptr++];
+
+        half2 h_01 = __halves2half2(h_0, h_1);
+        half2 h_23 = __halves2half2(h_2, h_3);
+        half2 h_45 = __halves2half2(h_4, h_5);
+        half2 h_67 = __halves2half2(h_6, h_7);
+
+        half2 tmp = __hmul2(h_01, v_01);
+        tmp = __hfma2(h_23, v_23, tmp);
+        tmp = __hfma2(h_45, v_45, tmp);
+        tmp = __hfma2(h_67, v_67, tmp);
+        result = __hfma2(v_scale_2, tmp, result);
+    }
+
+    return result;
+}
+
+__device__ __forceinline__ half dot_product_8_x_map_h
+(
+    const half acc,
+    MatrixView_half& h_,
+    const int h_row,
+    const int h_column,                 // divisible by 8
+    MatrixView_q4_column& v_,
+    const int v_row,                    // divisible by 8
+    const int v_column,
+    const half v_scale,
+    const uint32_t v_zero,              // + 1 (!!)
+    const int count,
+    const uint32_t* x_map
+)
+{
+    const half* h_ptr = h_.item_ptr(h_row, 0);
+    const uint32_t* x_map_ptr = x_map + h_column;
+    const uint32_t* v_ptr = (const uint32_t*) v_.item_uint32_ptr(v_row, v_column);
+    half result = acc;
+
+    for (int i = 0; i < count; i++)
+    {
+        uint32_t v_read = *v_ptr; v_ptr += v_.width;
+
+        half v_0 = __int2half_rn((int)((v_read      ) & 0x0f) - v_zero);
+        half v_1 = __int2half_rn((int)((v_read >>  4) & 0x0f) - v_zero);
+        half v_2 = __int2half_rn((int)((v_read >>  8) & 0x0f) - v_zero);
+        half v_3 = __int2half_rn((int)((v_read >> 12) & 0x0f) - v_zero);
+        half v_4 = __int2half_rn((int)((v_read >> 16) & 0x0f) - v_zero);
+        half v_5 = __int2half_rn((int)((v_read >> 20) & 0x0f) - v_zero);
+        half v_6 = __int2half_rn((int)((v_read >> 24) & 0x0f) - v_zero);
+        half v_7 = __int2half_rn((int)((v_read >> 28)       ) - v_zero);
+
+        half tmp = __hmul(h_ptr[*x_map_ptr++], v_0);
+        tmp = __hfma(h_ptr[*x_map_ptr++], v_1, tmp);
+        tmp = __hfma(h_ptr[*x_map_ptr++], v_2, tmp);
+        tmp = __hfma(h_ptr[*x_map_ptr++], v_3, tmp);
+        tmp = __hfma(h_ptr[*x_map_ptr++], v_4, tmp);
+        tmp = __hfma(h_ptr[*x_map_ptr++], v_5, tmp);
+        tmp = __hfma(h_ptr[*x_map_ptr++], v_6, tmp);
+        tmp = __hfma(h_ptr[*x_map_ptr++], v_7, tmp);
+        result = __hfma(v_scale, tmp, result);
+    }
+
+    return result;
+}
+
+#endif

--- a/slora/models/exllama_kernels/exllama_kernels/tuning.h
+++ b/slora/models/exllama_kernels/exllama_kernels/tuning.h
@@ -1,0 +1,13 @@
+// Adapted from turboderp exllama: https://github.com/turboderp/exllama
+
+#ifndef _tuning_h
+#define _tuning_h
+
+struct ExLlamaTuning
+{
+    int matmul_recons_thd;
+    bool matmul_fused_remap;
+    bool matmul_no_half2;
+};
+
+#endif

--- a/slora/models/exllama_kernels/exllama_kernels/util.cuh
+++ b/slora/models/exllama_kernels/exllama_kernels/util.cuh
@@ -1,0 +1,29 @@
+// Adapted from turboderp exllama: https://github.com/turboderp/exllama
+
+#ifndef _util_cuh
+#define _util_cuh
+
+#include <cuda_runtime.h>
+#include <cuda_fp16.h>
+#include <cstdint>
+#include <cstdio>
+
+#define cudaUnspecified cudaErrorApiFailureBase
+
+// React to failure on return code != cudaSuccess
+
+#define _cuda_check(fn) \
+do { \
+    {_cuda_err = fn;} \
+    if (_cuda_err != cudaSuccess) goto _cuda_fail; \
+} while(false)
+
+// React to failure on return code == 0
+
+#define _alloc_check(fn) \
+do { \
+    if (!(fn)) { _cuda_err = cudaUnspecified; goto _cuda_fail; } \
+    else _cuda_err = cudaSuccess; \
+} while(false)
+
+#endif

--- a/slora/models/exllama_kernels/setup.py
+++ b/slora/models/exllama_kernels/setup.py
@@ -1,0 +1,19 @@
+from setuptools import setup
+from torch.utils.cpp_extension import BuildExtension, CUDAExtension
+
+setup(
+    name="exllama_kernels",
+    ext_modules=[
+        CUDAExtension(
+            name="exllama_kernels",
+            sources=[
+                "exllama_kernels/exllama_ext.cpp",
+                "exllama_kernels/cuda_buffers.cu",
+                "exllama_kernels/cuda_func/column_remap.cu",
+                "exllama_kernels/cuda_func/q4_matmul.cu",
+                "exllama_kernels/cuda_func/q4_matrix.cu",
+            ],
+        )
+    ],
+    cmdclass={"build_ext": BuildExtension},
+)

--- a/slora/models/gptq/custom_autotune.py
+++ b/slora/models/gptq/custom_autotune.py
@@ -1,0 +1,261 @@
+# https://github.com/fpgaminer/GPTQ-triton
+"""
+Mostly the same as the autotuner in Triton, but with a few changes like using 40 runs instead of 100.
+"""
+
+import builtins
+import math
+import time
+from typing import Dict
+
+import triton
+
+
+class Autotuner(triton.KernelInterface):
+    def __init__(
+        self,
+        fn,
+        arg_names,
+        configs,
+        key,
+        reset_to_zero,
+        prune_configs_by: Dict = None,
+        nearest_power_of_two: bool = False,
+    ):
+        """
+        :param prune_configs_by: a dict of functions that are used to prune configs, fields:
+                'perf_model': performance model used to predicate running time with different configs, returns running time
+                'top_k': number of configs to bench
+                'prune_num_stages_by'(optional): a function used to prune num_stages. It take configs:List[Config] as its input, and returns pruned configs.
+                'nearest_power_of_two'(optional): whether to round key arguments to the nearest power of two when caching tuning results
+        """
+        if not configs:
+            self.configs = [triton.Config({}, num_warps=4, num_stages=2)]
+        else:
+            self.configs = configs
+        self.key_idx = [arg_names.index(k) for k in key]
+        self.nearest_power_of_two = nearest_power_of_two
+        self.cache = {}
+        # hook to reset all required tensor to zeros before relaunching a kernel
+        self.hook = lambda args: 0
+        if reset_to_zero is not None:
+            self.reset_idx = [arg_names.index(k) for k in reset_to_zero]
+
+            def _hook(args):
+                for i in self.reset_idx:
+                    args[i].zero_()
+
+            self.hook = _hook
+        self.arg_names = arg_names
+        # prune configs
+        if prune_configs_by:
+            perf_model, top_k = (
+                prune_configs_by["perf_model"],
+                prune_configs_by["top_k"],
+            )
+            if "early_config_prune" in prune_configs_by:
+                early_config_prune = prune_configs_by["early_config_prune"]
+        else:
+            perf_model, top_k, early_config_prune = None, None, None
+        self.perf_model, self.configs_top_k = perf_model, top_k
+        self.early_config_prune = early_config_prune
+        self.fn = fn
+
+    def _bench(self, *args, config, **meta):
+        # check for conflicts, i.e. meta-parameters both provided
+        # as kwargs and by the autotuner
+        conflicts = meta.keys() & config.kwargs.keys()
+        if conflicts:
+            raise ValueError(
+                f"Conflicting meta-parameters: {', '.join(conflicts)}."
+                " Make sure that you don't re-define auto-tuned symbols."
+            )
+        # augment meta-parameters with tunable ones
+        current = dict(meta, **config.kwargs)
+
+        def kernel_call():
+            if config.pre_hook:
+                config.pre_hook(self.nargs)
+            self.hook(args)
+            self.fn.run(
+                *args,
+                num_warps=config.num_warps,
+                num_stages=config.num_stages,
+                **current,
+            )
+
+        try:
+            # In testings using only 40 reps seems to be close enough and it appears to be what PyTorch uses
+            # PyTorch also sets fast_flush to True, but I didn't see any speedup so I'll leave the default
+            return triton.testing.do_bench(
+                kernel_call, quantiles=(0.5, 0.2, 0.8), rep=40
+            )
+        except triton.compiler.CompilationError:
+            return (float("inf"), float("inf"), float("inf"))
+
+    def run(self, *args, **kwargs):
+        self.nargs = dict(zip(self.arg_names, args))
+        if len(self.configs) > 1:
+            key = tuple(args[i] for i in self.key_idx)
+
+            # This reduces the amount of autotuning by rounding the keys to the nearest power of two
+            # In my testing this gives decent results, and greatly reduces the amount of tuning required
+            if self.nearest_power_of_two:
+                key = tuple([2 ** int(math.log2(x) + 0.5) for x in key])
+
+            if key not in self.cache:
+                # prune configs
+                pruned_configs = self.prune_configs(kwargs)
+                bench_start = time.time()
+                timings = {
+                    config: self._bench(*args, config=config, **kwargs)
+                    for config in pruned_configs
+                }
+                bench_end = time.time()
+                self.bench_time = bench_end - bench_start
+                self.cache[key] = builtins.min(timings, key=timings.get)
+                self.hook(args)
+                self.configs_timings = timings
+            config = self.cache[key]
+        else:
+            config = self.configs[0]
+        self.best_config = config
+        if config.pre_hook is not None:
+            config.pre_hook(self.nargs)
+        return self.fn.run(
+            *args,
+            num_warps=config.num_warps,
+            num_stages=config.num_stages,
+            **kwargs,
+            **config.kwargs,
+        )
+
+    def prune_configs(self, kwargs):
+        pruned_configs = self.configs
+        if self.early_config_prune:
+            pruned_configs = self.early_config_prune(self.configs, self.nargs)
+        if self.perf_model:
+            top_k = self.configs_top_k
+            if isinstance(top_k, float) and top_k <= 1.0:
+                top_k = int(len(self.configs) * top_k)
+            if len(pruned_configs) > top_k:
+                est_timing = {
+                    config: self.perf_model(
+                        **self.nargs,
+                        **kwargs,
+                        **config.kwargs,
+                        num_stages=config.num_stages,
+                        num_warps=config.num_warps,
+                    )
+                    for config in pruned_configs
+                }
+                pruned_configs = sorted(est_timing.keys(), key=lambda x: est_timing[x])[
+                    :top_k
+                ]
+        return pruned_configs
+
+    def warmup(self, *args, **kwargs):
+        self.nargs = dict(zip(self.arg_names, args))
+        for config in self.prune_configs(kwargs):
+            self.fn.warmup(
+                *args,
+                num_warps=config.num_warps,
+                num_stages=config.num_stages,
+                **kwargs,
+                **config.kwargs,
+            )
+        self.nargs = None
+
+
+def autotune(
+    configs, key, prune_configs_by=None, reset_to_zero=None, nearest_power_of_two=False
+):
+    """
+    Decorator for auto-tuning a :code:`triton.jit`'d function.
+    .. highlight:: python
+    .. code-block:: python
+            @triton.autotune(configs=[
+                    triton.Config(meta={'BLOCK_SIZE': 128}, num_warps=4),
+                    triton.Config(meta={'BLOCK_SIZE': 1024}, num_warps=8),
+                    ],
+                    key=['x_size'] # the two above configs will be evaluated anytime
+                                                    # the value of x_size changes
+            )
+            @triton.jit
+            def kernel(x_ptr, x_size, **META):
+                    BLOCK_SIZE = META['BLOCK_SIZE']
+    :note: When all the configurations are evaluated, the kernel will run multiple time.
+                    This means that whatever value the kernel updates will be updated multiple times.
+                    To avoid this undesired behavior, you can use the `reset_to_zero` argument, which
+                    reset the value of the provided tensor to `zero` before running any configuration.
+    :param configs: a list of :code:`triton.Config` objects
+    :type configs: list[triton.Config]
+    :param key: a list of argument names whose change in value will trigger the evaluation of all provided configs.
+    :type key: list[str]
+    :param prune_configs_by: a dict of functions that are used to prune configs, fields:
+            'perf_model': performance model used to predicate running time with different configs, returns running time
+            'top_k': number of configs to bench
+            'early_config_prune'(optional): a function used to do early prune (eg, num_stages). It take configs:List[Config] as its input, and returns pruned configs.
+    :param reset_to_zero: a list of argument names whose value will be reset to zero before evaluating any configs.
+    :type reset_to_zero: list[str]
+    """
+
+    def decorator(fn):
+        return Autotuner(
+            fn,
+            fn.arg_names,
+            configs,
+            key,
+            reset_to_zero,
+            prune_configs_by,
+            nearest_power_of_two,
+        )
+
+    return decorator
+
+
+def matmul248_kernel_config_pruner(configs, nargs):
+    """
+    The main purpose of this function is to shrink BLOCK_SIZE_* when the corresponding dimension is smaller.
+    """
+    m = max(2 ** int(math.ceil(math.log2(nargs["M"]))), 16)
+    n = max(2 ** int(math.ceil(math.log2(nargs["N"]))), 16)
+    k = max(2 ** int(math.ceil(math.log2(nargs["K"]))), 16)
+
+    used = set()
+    for config in configs:
+        block_size_m = min(m, config.kwargs["BLOCK_SIZE_M"])
+        block_size_n = min(n, config.kwargs["BLOCK_SIZE_N"])
+        block_size_k = min(k, config.kwargs["BLOCK_SIZE_K"])
+        group_size_m = config.kwargs["GROUP_SIZE_M"]
+
+        if (
+            block_size_m,
+            block_size_n,
+            block_size_k,
+            group_size_m,
+            config.num_stages,
+            config.num_warps,
+        ) in used:
+            continue
+
+        used.add(
+            (
+                block_size_m,
+                block_size_n,
+                block_size_k,
+                group_size_m,
+                config.num_stages,
+                config.num_warps,
+            )
+        )
+        yield triton.Config(
+            {
+                "BLOCK_SIZE_M": block_size_m,
+                "BLOCK_SIZE_N": block_size_n,
+                "BLOCK_SIZE_K": block_size_k,
+                "GROUP_SIZE_M": group_size_m,
+            },
+            num_stages=config.num_stages,
+            num_warps=config.num_warps,
+        )

--- a/slora/models/gptq/exllama.py
+++ b/slora/models/gptq/exllama.py
@@ -1,0 +1,140 @@
+import torch
+from exllama_kernels import make_q4, q4_matmul, prepare_buffers, set_tuning_params
+
+# Dummy tensor to pass instead of g_idx since there is no way to pass "None" to a C++ extension
+none_tensor = torch.empty((1, 1), device="meta")
+
+
+def ext_make_q4(qweight, qzeros, scales, g_idx, device):
+    """Construct Q4Matrix, return handle"""
+    return make_q4(
+        qweight, qzeros, scales, g_idx if g_idx is not None else none_tensor, device
+    )
+
+
+def ext_q4_matmul(x, q4, q4_width, cache=None):
+    """Matrix multiplication, returns x @ q4"""
+    outshape = x.shape[:-1] + (q4_width,)
+    x = x.view(-1, x.shape[-1])
+    if cache is None:
+        cache = torch.empty((x.shape[0], q4_width), dtype=torch.float16, device=x.device)
+
+    q4_matmul(x, q4, cache)
+
+    return cache.view(outshape)
+
+
+MAX_DQ = 1
+MAX_INNER = 1
+ACT_ORDER = False
+DEVICE = None
+
+TEMP_STATE = None
+TEMP_DQ = None
+
+
+def set_device(device):
+    global DEVICE
+    DEVICE = device
+
+
+def create_exllama_buffers():
+    global MAX_DQ, MAX_INNER, ACT_ORDER, DEVICE, TEMP_STATE, TEMP_DQ
+
+    assert DEVICE is not None, "call set_device first"
+
+    if ACT_ORDER:
+        # TODO: this should be set to rust side `max_total_tokens`, but TGI
+        # does not offer an API to expose this variable to python, as this variable
+        # is handled by the client but it appears the model is initialized by the server.
+        # An alternative could be to initialize the buffers during warmup.
+        # Dummy
+        max_total_tokens = 2048
+    else:
+        max_total_tokens = 1
+
+    # This temp_state buffer is required to reorder X in the act-order case.
+    temp_state = torch.zeros(
+        (max_total_tokens, MAX_INNER), dtype=torch.float16, device=DEVICE
+    )
+    temp_dq = torch.zeros((1, MAX_DQ), dtype=torch.float16, device=DEVICE)
+
+    # This temp_dq buffer is required to dequantize weights when using cuBLAS, typically for the prefill.
+    prepare_buffers(DEVICE, temp_state, temp_dq)
+
+    matmul_recons_thd = 8
+    matmul_fused_remap = False
+    matmul_no_half2 = False
+    set_tuning_params(matmul_recons_thd, matmul_fused_remap, matmul_no_half2)
+
+    TEMP_STATE, TEMP_DQ = temp_state, temp_dq
+
+
+class Ex4bitLinear(torch.nn.Module):
+    """Linear layer implementation with per-group 4-bit quantization of the weights"""
+
+    def __init__(self, qweight, qzeros, scales, g_idx, bias, bits, groupsize):
+        super().__init__()
+        global MAX_DQ, MAX_INNER, ACT_ORDER, DEVICE
+        assert bits == 4
+
+        self.device = qweight.device
+        self.qweight = qweight
+        self.qzeros = qzeros
+        self.scales = scales
+        self.g_idx = g_idx.cpu() if g_idx is not None else None
+        self.bias = bias if bias is not None else None
+
+        if self.g_idx is not None and (
+            (self.g_idx == 0).all()
+            or torch.equal(
+                g_idx.cpu(),
+                torch.tensor(
+                    [i // groupsize for i in range(g_idx.shape[0])], dtype=torch.int32
+                ),
+            )
+        ):
+            self.empty_g_idx = True
+            self.g_idx = None
+
+        assert self.device.type == "cuda"
+        assert self.device.index is not None
+
+        self.q4 = ext_make_q4(
+            self.qweight, self.qzeros, self.scales, self.g_idx, self.device.index
+        )
+
+        self.height = qweight.shape[0] * 8
+        self.width = qweight.shape[1]
+
+        # Infer groupsize from height of qzeros
+        self.groupsize = None
+        if self.qzeros.shape[0] > 1:
+            self.groupsize = (self.qweight.shape[0] * 8) // (self.qzeros.shape[0])
+
+        if self.groupsize is not None:
+            assert groupsize == self.groupsize
+
+        # Handle act-order matrix
+        if self.g_idx is not None:
+            if self.groupsize is None:
+                raise ValueError("Found group index but no groupsize. What do?")
+            self.act_order = True
+        else:
+            self.act_order = False
+
+        DEVICE = self.qweight.device
+
+        MAX_DQ = max(MAX_DQ, self.qweight.numel() * 8)
+
+        if self.act_order:
+            MAX_INNER = max(MAX_INNER, self.height, self.width)
+
+            ACT_ORDER = True
+
+    def forward(self, x, cache=None):
+        out = ext_q4_matmul(x, self.q4, self.width, cache=cache)
+
+        if self.bias is not None:
+            out.add_(self.bias)
+        return out

--- a/slora/models/gptq/quant_linear.py
+++ b/slora/models/gptq/quant_linear.py
@@ -1,0 +1,375 @@
+import math
+import numpy as np
+import torch
+import torch.nn as nn
+from torch.cuda.amp import custom_bwd, custom_fwd
+
+try:
+    import triton
+    import triton.language as tl
+    from . import custom_autotune
+
+    # code based https://github.com/fpgaminer/GPTQ-triton
+    @custom_autotune.autotune(
+        configs=[
+            triton.Config(
+                {
+                    "BLOCK_SIZE_M": 64,
+                    "BLOCK_SIZE_N": 256,
+                    "BLOCK_SIZE_K": 32,
+                    "GROUP_SIZE_M": 8,
+                },
+                num_stages=4,
+                num_warps=4,
+            ),
+            triton.Config(
+                {
+                    "BLOCK_SIZE_M": 128,
+                    "BLOCK_SIZE_N": 128,
+                    "BLOCK_SIZE_K": 32,
+                    "GROUP_SIZE_M": 8,
+                },
+                num_stages=4,
+                num_warps=4,
+            ),
+            triton.Config(
+                {
+                    "BLOCK_SIZE_M": 64,
+                    "BLOCK_SIZE_N": 128,
+                    "BLOCK_SIZE_K": 32,
+                    "GROUP_SIZE_M": 8,
+                },
+                num_stages=4,
+                num_warps=4,
+            ),
+            triton.Config(
+                {
+                    "BLOCK_SIZE_M": 128,
+                    "BLOCK_SIZE_N": 32,
+                    "BLOCK_SIZE_K": 32,
+                    "GROUP_SIZE_M": 8,
+                },
+                num_stages=4,
+                num_warps=4,
+            ),
+            triton.Config(
+                {
+                    "BLOCK_SIZE_M": 64,
+                    "BLOCK_SIZE_N": 64,
+                    "BLOCK_SIZE_K": 32,
+                    "GROUP_SIZE_M": 8,
+                },
+                num_stages=4,
+                num_warps=4,
+            ),
+            triton.Config(
+                {
+                    "BLOCK_SIZE_M": 64,
+                    "BLOCK_SIZE_N": 128,
+                    "BLOCK_SIZE_K": 32,
+                    "GROUP_SIZE_M": 8,
+                },
+                num_stages=2,
+                num_warps=8,
+            ),
+            triton.Config(
+                {
+                    "BLOCK_SIZE_M": 64,
+                    "BLOCK_SIZE_N": 64,
+                    "BLOCK_SIZE_K": 64,
+                    "GROUP_SIZE_M": 8,
+                },
+                num_stages=3,
+                num_warps=8,
+            ),
+            triton.Config(
+                {
+                    "BLOCK_SIZE_M": 32,
+                    "BLOCK_SIZE_N": 32,
+                    "BLOCK_SIZE_K": 128,
+                    "GROUP_SIZE_M": 8,
+                },
+                num_stages=2,
+                num_warps=4,
+            ),
+        ],
+        key=["M", "N", "K"],
+        nearest_power_of_two=True,
+        prune_configs_by={
+            "early_config_prune": custom_autotune.matmul248_kernel_config_pruner,
+            "perf_model": None,
+            "top_k": None,
+        },
+    )
+    @triton.jit
+    def matmul_248_kernel(
+        a_ptr,
+        b_ptr,
+        c_ptr,
+        scales_ptr,
+        zeros_ptr,
+        g_ptr,
+        M,
+        N,
+        K,
+        bits,
+        maxq,
+        stride_am,
+        stride_ak,
+        stride_bk,
+        stride_bn,
+        stride_cm,
+        stride_cn,
+        stride_scales,
+        stride_zeros,
+        BLOCK_SIZE_M: tl.constexpr,
+        BLOCK_SIZE_N: tl.constexpr,
+        BLOCK_SIZE_K: tl.constexpr,
+        GROUP_SIZE_M: tl.constexpr,
+    ):
+        """
+        Compute the matrix multiplication C = A x B.
+        A is of shape (M, K) float16
+        B is of shape (K//8, N) int32
+        C is of shape (M, N) float16
+        scales is of shape (G, N) float16
+        zeros is of shape (G, N) float16
+        g_ptr is of shape (K) int32
+        """
+        infearure_per_bits = 32 // bits
+
+        pid = tl.program_id(axis=0)
+        num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
+        num_pid_n = tl.cdiv(N, BLOCK_SIZE_N)
+        num_pid_k = tl.cdiv(K, BLOCK_SIZE_K)
+        num_pid_in_group = GROUP_SIZE_M * num_pid_n
+        group_id = pid // num_pid_in_group
+        first_pid_m = group_id * GROUP_SIZE_M
+        group_size_m = min(num_pid_m - first_pid_m, GROUP_SIZE_M)
+        pid_m = first_pid_m + (pid % group_size_m)
+        pid_n = (pid % num_pid_in_group) // group_size_m
+
+        offs_am = pid_m * BLOCK_SIZE_M + tl.arange(0, BLOCK_SIZE_M)
+        offs_bn = pid_n * BLOCK_SIZE_N + tl.arange(0, BLOCK_SIZE_N)
+        offs_k = tl.arange(0, BLOCK_SIZE_K)
+        a_ptrs = a_ptr + (
+            offs_am[:, None] * stride_am + offs_k[None, :] * stride_ak
+        )  # (BLOCK_SIZE_M, BLOCK_SIZE_K)
+        a_mask = offs_am[:, None] < M
+        # b_ptrs is set up such that it repeats elements along the K axis 8 times
+        b_ptrs = b_ptr + (
+            (offs_k[:, None] // infearure_per_bits) * stride_bk
+            + offs_bn[None, :] * stride_bn
+        )  # (BLOCK_SIZE_K, BLOCK_SIZE_N)
+        g_ptrs = g_ptr + offs_k
+        # shifter is used to extract the N bits of each element in the 32-bit word from B
+        scales_ptrs = scales_ptr + offs_bn[None, :]
+        zeros_ptrs = zeros_ptr + (offs_bn[None, :] // infearure_per_bits)
+
+        shifter = (offs_k % infearure_per_bits) * bits
+        zeros_shifter = (offs_bn % infearure_per_bits) * bits
+        accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+        for k in range(0, num_pid_k):
+            g_idx = tl.load(g_ptrs)
+
+            # Fetch scales and zeros; these are per-outfeature and thus reused in the inner loop
+            scales = tl.load(
+                scales_ptrs + g_idx[:, None] * stride_scales
+            )  # (BLOCK_SIZE_K, BLOCK_SIZE_N,)
+            zeros = tl.load(
+                zeros_ptrs + g_idx[:, None] * stride_zeros
+            )  # (BLOCK_SIZE_K, BLOCK_SIZE_N,)
+
+            zeros = (zeros >> zeros_shifter[None, :]) & maxq
+            zeros = zeros + 1
+
+            a = tl.load(a_ptrs, mask=a_mask, other=0.0)  # (BLOCK_SIZE_M, BLOCK_SIZE_K)
+            b = tl.load(b_ptrs)  # (BLOCK_SIZE_K, BLOCK_SIZE_N), but repeated
+
+            # Now we need to unpack b (which is N-bit values) into 32-bit values
+            b = (b >> shifter[:, None]) & maxq  # Extract the N-bit values
+            b = (b - zeros) * scales  # Scale and shift
+
+            accumulator += tl.dot(a, b)
+            a_ptrs += BLOCK_SIZE_K
+            b_ptrs += (BLOCK_SIZE_K // infearure_per_bits) * stride_bk
+            g_ptrs += BLOCK_SIZE_K
+
+        c_ptrs = c_ptr + stride_cm * offs_am[:, None] + stride_cn * offs_bn[None, :]
+        c_mask = (offs_am[:, None] < M) & (offs_bn[None, :] < N)
+        tl.store(c_ptrs, accumulator, mask=c_mask)
+
+except:
+    print("triton not installed.")
+
+
+def matmul248(input, qweight, scales, qzeros, g_idx, bits, maxq, output):
+    with torch.cuda.device(input.device):
+        if output is None:
+            output = torch.empty(
+                (input.shape[0], qweight.shape[1]), device=input.device, dtype=torch.float16
+            )
+        grid = lambda META: (
+            triton.cdiv(input.shape[0], META["BLOCK_SIZE_M"])
+            * triton.cdiv(qweight.shape[1], META["BLOCK_SIZE_N"]),
+        )
+        matmul_248_kernel[grid](
+            input,
+            qweight,
+            output,
+            scales,
+            qzeros,
+            g_idx,
+            input.shape[0],
+            qweight.shape[1],
+            input.shape[1],
+            bits,
+            maxq,
+            input.stride(0),
+            input.stride(1),
+            qweight.stride(0),
+            qweight.stride(1),
+            output.stride(0),
+            output.stride(1),
+            scales.stride(0),
+            qzeros.stride(0),
+        )
+        return output
+
+
+class QuantLinearFunction(torch.autograd.Function):
+    @staticmethod
+    @custom_fwd(cast_inputs=torch.float16)
+    def forward(ctx, input, qweight, scales, qzeros, g_idx, bits, maxq, cache):
+        output = matmul248(input, qweight, scales, qzeros, g_idx, bits, maxq, cache)
+        return output
+
+
+class QuantLinear(nn.Module):
+    def __init__(self, qweight, qzeros, scales, g_idx, bias, bits, groupsize):
+        super().__init__()
+        self.register_buffer("qweight", qweight)
+        self.register_buffer("qzeros", qzeros)
+        self.register_buffer("scales", scales)
+        self.register_buffer("g_idx", g_idx)
+        if bias is not None:
+            self.register_buffer("bias", bias)
+        else:
+            self.bias = None
+        if bits not in [2, 4, 8]:
+            raise NotImplementedError("Only 2,4,8 bits are supported.")
+        self.bits = bits
+        self.maxq = 2**self.bits - 1
+        self.groupsize = groupsize
+
+        self.outfeatures = qweight.shape[1]
+        self.infeatures = qweight.shape[0] * 32 // bits
+
+    @classmethod
+    def new(cls, bits, groupsize, infeatures, outfeatures, bias):
+        if bits not in [2, 4, 8]:
+            raise NotImplementedError("Only 2,4,8 bits are supported.")
+
+        qweight = torch.zeros((infeatures // 32 * bits, outfeatures), dtype=torch.int32)
+        qzeros = torch.zeros(
+            (math.ceil(infeatures / groupsize), outfeatures // 32 * bits),
+            dtype=torch.int32,
+        )
+        scales = torch.zeros(
+            (math.ceil(infeatures / groupsize), outfeatures), dtype=torch.float16
+        )
+        g_idx = torch.tensor(
+            [i // groupsize for i in range(infeatures)], dtype=torch.int32
+        )
+        if bias:
+            bias = torch.zeros((outfeatures), dtype=torch.float16)
+        else:
+            bias = None
+        return cls(qweight, qzeros, scales, g_idx, bias, bits, groupsize)
+
+    def pack(self, linear, scales, zeros, g_idx=None):
+        self.g_idx = g_idx.clone() if g_idx is not None else self.g_idx
+
+        scales = scales.t().contiguous()
+        zeros = zeros.t().contiguous()
+        scale_zeros = zeros * scales
+        self.scales = scales.clone().half()
+        if linear.bias is not None:
+            self.bias = linear.bias.clone().half()
+
+        intweight = []
+        for idx in range(self.infeatures):
+            intweight.append(
+                torch.round(
+                    (linear.weight.data[:, idx] + scale_zeros[self.g_idx[idx]])
+                    / self.scales[self.g_idx[idx]]
+                ).to(torch.int)[:, None]
+            )
+        intweight = torch.cat(intweight, dim=1)
+        intweight = intweight.t().contiguous()
+        intweight = intweight.numpy().astype(np.uint32)
+        qweight = np.zeros(
+            (intweight.shape[0] // 32 * self.bits, intweight.shape[1]), dtype=np.uint32
+        )
+        i = 0
+        row = 0
+        while row < qweight.shape[0]:
+            if self.bits in [2, 4, 8]:
+                for j in range(i, i + (32 // self.bits)):
+                    qweight[row] |= intweight[j] << (self.bits * (j - i))
+                i += 32 // self.bits
+                row += 1
+            else:
+                raise NotImplementedError("Only 2,4,8 bits are supported.")
+
+        qweight = qweight.astype(np.int32)
+        self.qweight = torch.from_numpy(qweight)
+
+        zeros -= 1
+        zeros = zeros.numpy().astype(np.uint32)
+        qzeros = np.zeros(
+            (zeros.shape[0], zeros.shape[1] // 32 * self.bits), dtype=np.uint32
+        )
+        i = 0
+        col = 0
+        while col < qzeros.shape[1]:
+            if self.bits in [2, 4, 8]:
+                for j in range(i, i + (32 // self.bits)):
+                    qzeros[:, col] |= zeros[:, j] << (self.bits * (j - i))
+                i += 32 // self.bits
+                col += 1
+            else:
+                raise NotImplementedError("Only 2,4,8 bits are supported.")
+
+        qzeros = qzeros.astype(np.int32)
+        self.qzeros = torch.from_numpy(qzeros)
+
+    def forward(self, x, cache=None):
+        out_shape = x.shape[:-1] + (self.outfeatures,)
+        if cache is None:
+            out = QuantLinearFunction.apply(
+                x.reshape(-1, x.shape[-1]),
+                self.qweight,
+                self.scales,
+                self.qzeros,
+                self.g_idx,
+                self.bits,
+                self.maxq,
+                None
+            )
+            out = out + self.bias if self.bias is not None else out
+            return out.reshape(out_shape)
+        else:
+            cache = QuantLinearFunction.apply(
+                x.reshape(-1, x.shape[-1]),
+                self.qweight,
+                self.scales,
+                self.qzeros,
+                self.g_idx,
+                self.bits,
+                self.maxq,
+                cache
+            )
+            cache = cache + self.bias if self.bias is not None else cache
+            return cache.reshape(out_shape)

--- a/slora/models/llama2_quant/layer_infer/transformer_layer_infer.py
+++ b/slora/models/llama2_quant/layer_infer/transformer_layer_infer.py
@@ -1,0 +1,20 @@
+import torch
+import torch.functional as F
+import torch.distributed as dist
+import numpy as np
+import triton
+
+from slora.models.llama2.layer_infer.transformer_layer_infer import Llama2TransformerLayerInfer
+from slora.models.llama2_quant.layer_weights.transformer_layer_weight import QuantLlama2TransformerLayerWeight
+
+class QuantLlama2TransformerLayerInfer(Llama2TransformerLayerInfer):
+    def _ffn(self, input, infer_state, layer_weight:QuantLlama2TransformerLayerWeight)->torch.Tensor:
+        gate_out = layer_weight.gate_layer(input.view(-1, self.embed_dim_))
+        torch.nn.functional.silu(gate_out, inplace=True)
+        up_out = layer_weight.up_layer(input.view(-1, self.embed_dim_))
+        input = None
+        ffn1_out = gate_out * up_out
+        gate_out, up_out = None, None
+        ffn2_out = layer_weight.down_layer(ffn1_out)
+        ffn1_out = None
+        return ffn2_out

--- a/slora/models/llama2_quant/layer_weights/hf_load_utils.py
+++ b/slora/models/llama2_quant/layer_weights/hf_load_utils.py
@@ -1,0 +1,49 @@
+import gc
+import os
+from safetensors import safe_open
+import torch
+from tqdm import tqdm
+
+def load_hf_quant_weights(pre_post_datatype, trans_datatype, weight_dir, pre_post_layer=None, transformer_layer_list=None, dummy=False):
+    pre_post_datatype = torch.float16 if pre_post_datatype == "fp16" else torch.float32
+    if trans_datatype == "int32":
+        trans_datatype = torch.int32
+    else:
+        raise ValueError(f"The trans_datatype should be int32, but got {trans_datatype}")
+    
+    if pre_post_layer is not None:
+        assert pre_post_layer.data_type_ == pre_post_datatype, f"type is not right, {pre_post_layer.data_type_ } v.s. {pre_post_datatype}"
+    if transformer_layer_list is not None:
+        assert transformer_layer_list[0].data_type_ == trans_datatype, f"type is not right, {transformer_layer_list[0].data_type_} v.s. {trans_datatype}"
+    
+    if dummy:
+        if pre_post_layer is not None:
+            pre_post_layer.load_hf_weights(None, dummy=dummy)
+        if transformer_layer_list is not None:
+            model_name = weight_dir.rstrip("/").split("/")[-1]
+            for layer in tqdm(transformer_layer_list, desc=f"load model {model_name}"):
+                layer.load_hf_weights(None, dummy=dummy)
+        return
+
+    use_safetensors = True
+    files = os.listdir(weight_dir)
+    candidate_files = list(filter(lambda x : x.endswith('.safetensors'), files))
+    if len(candidate_files) == 0:
+        use_safetensors = False
+        candidate_files = list(filter(lambda x : x.endswith('.bin'), files))
+    assert len(candidate_files) != 0, "can only support pytorch tensor and safetensors format for weights."
+
+    for file_ in candidate_files:
+        if use_safetensors:
+            weights = safe_open(os.path.join(weight_dir, file_), 'pt', 'cpu')
+            weights = {k: weights.get_tensor(k) for k in weights.keys()}
+        else:
+            weights = torch.load(os.path.join(weight_dir, file_), 'cpu')
+        if pre_post_layer is not None:
+            pre_post_layer.load_hf_weights(weights)
+        if transformer_layer_list is not None:
+            for layer in transformer_layer_list:
+                layer.load_hf_weights(weights)
+        del weights
+        gc.collect()
+    return

--- a/slora/models/llama2_quant/layer_weights/transformer_layer_weight.py
+++ b/slora/models/llama2_quant/layer_weights/transformer_layer_weight.py
@@ -1,0 +1,484 @@
+import torch
+import math
+import warnings
+import numpy as np
+import os
+
+MAX_INT = 2147483647
+MIN_INT = -2147483648
+
+try:
+    major, _minor = torch.cuda.get_device_capability()
+except Exception:
+    major = 1
+
+USE_EXLLAMA = os.environ.get("USE_EXLLAMA", "True")
+USE_EXLLAMA = True if USE_EXLLAMA == "True" else False
+HAS_EXLLAMA = False
+CAN_EXLLAMA = major >= 8
+if CAN_EXLLAMA:
+    try:
+        from slora.models.gptq.exllama import Ex4bitLinear
+        HAS_EXLLAMA = True
+    except ImportError:
+        warnings.warn(
+            f"""
+            Can not import `Ex4bitLinear` from exllama, the current compute capability is {major}.{_minor}. `exllama` need compute capability greater than 8.0.
+
+            If your compute capability is greater than 8.0, please check if you have installed the `exllama` package. 
+
+            You can install it follow the following instructions:
+            ```
+                cd slora/models/exllama
+                pip install -v -e .
+            ```
+            """
+        )
+        
+        # raise NotImplemented("`QuantLlama2TransformerLayerWeight` only support 4-bit gptq quantization now, and use `exllama` to implement the Linear layer. Please make sure you can use the `exllama` and you have installed the `exllama` package.")
+
+from slora.models.gptq.quant_linear import QuantLinear
+from slora.common.basemodel import TransformerLayerWeight
+
+from slora.models.llama.layer_weights.transformer_layer_weight import LlamaTransformerLayerWeight
+
+"""
+As we use the implementation of tgi instead of the implementaton of triton_kernel to build the transformer layer infer process, we will build some layers here.
+TODO: In order to keep the consistency with other models' implementations defined in LightLLM, we may need to remove the layers defined in this class and use triton_kernel in the inference process of the transformer layer.
+
+For each FC weights, gptq has:
+    1. qweight: torch.int32
+    2. qzeros: torch.int32
+    3. scales: torch.float16
+    4. g_idx: torch.int32
+    5. bias: torch.float16
+PS: the dtype is the default dtype
+
+For Llama2 model, we use all the former 4 items, but ignore the `bias` following the TGI framework. After checking the existing model weights, all the `bias` are zero tensors.
+
+TODO: Notes: Qwen-14B-Chat-Int4, which uses the auto-gptq, has non-zero tensors.
+"""
+
+class QuantLlama2TransformerLayerWeight(TransformerLayerWeight):
+    def __init__(self, layer_num, tp_rank, world_size, data_type, network_config, mode=[]):
+        super().__init__(layer_num, tp_rank, world_size, data_type, network_config, mode)
+        # Nowadays, we only support the gptq.
+        assert "gptq" in mode, "Please check the `mode` arg, QuantLlama2TransformerLayerWeight only support the gptq quantization now."
+        # For simplicity, we assumpt that the world_size is 1 now
+        assert world_size == 1, f"For simplicity, `QuantLlama2TransformerLayerWeight` assumpt that the world_size is 1 now, but got {world_size}"
+        self.quantize_mode = "gptq"
+        self.quantize_config = network_config["quantize_config"]
+        self.quantize_bit = self.quantize_config["bits"]
+        self.quantize_groupsize = self.quantize_config["group_size"]
+        if self.data_type_ == torch.int32:
+            self.element_size = 32
+        else:
+            raise NotImplementedError("`QuantLlama2TransformerLayerWeight` only support int32 dtype now.")
+    
+    def load_hf_weights(self, weights, dummy=False):
+        if dummy:
+            self._load_qkvo_dummy_weights()
+            self._load_ffn_dummy_weights()
+        else:
+            self._load_qkvo_weights(weights)
+            self._load_ffn_weights(weights)
+
+    def verify_load(self):
+        errors = "weights load not ok"
+
+        fc_prefixs = ["q", "k", "v", "o", "up_proj", "gate_proj", "down_proj"]
+        quant_suffixs = []
+        if self.quantize_mode == "gptq":
+            # Notes: we ignore the bias, you should add bias if you need it
+            quant_suffixs += [
+                "qweight_", 
+                "qzeros_",
+                "scales_",
+                "g_idx",
+            ]
+        else:
+            raise NotImplementedError("`QuantLlama2TransformerLayerWeight` only support gptq now.")
+        
+        weights = []
+        for pre in fc_prefixs:
+            for suf in quant_suffixs:
+                weights.append(getattr(self, f"{pre}_{suf}"))
+
+        # add weights of the norm layers
+        weights += [self.att_norm_weight_, self.ffn_norm_weight_]
+
+        for i in range(len(weights)):
+            assert weights[i] is not None, "index:" + str(i) + " " + errors
+
+    """
+    Func `build_quant_layer` is used to build Quantize Linear layers.
+    This func will be called after calling `verify_load` func.
+    """
+    def build_quant_layer(self):
+        if self.quantize_mode == "gptq":
+            # check the g_idx
+            torch.testing.assert_close(self.q_g_idx, self.k_g_idx)
+            torch.testing.assert_close(self.q_g_idx, self.v_g_idx)
+            if self.use_exllama:
+                self.q_layer = Ex4bitLinear(
+                    self.q_qweight_, self.q_qzeros_, self.q_scales_, self.q_g_idx, None, self.quantize_bit, self.quantize_groupsize
+                )
+                self.k_layer = Ex4bitLinear(
+                    self.k_qweight_, self.k_qzeros_, self.k_scales_, self.k_g_idx, None, self.quantize_bit, self.quantize_groupsize
+                )
+                self.v_layer = Ex4bitLinear(
+                    self.v_qweight_, self.v_qzeros_, self.v_scales_, self.v_g_idx, None, self.quantize_bit, self.quantize_groupsize
+                )
+                self.o_layer = Ex4bitLinear(
+                    self.o_qweight_, self.o_qzeros_, self.o_scales_, self.o_g_idx, None, self.quantize_bit, self.quantize_groupsize
+                )
+                self.up_layer = Ex4bitLinear(
+                    self.up_proj_qweight_, self.up_proj_qzeros_, self.up_proj_scales_, self.up_proj_g_idx, None, self.quantize_bit, self.quantize_groupsize
+                )
+                self.gate_layer = Ex4bitLinear(
+                    self.gate_proj_qweight_, self.gate_proj_qzeros_, self.gate_proj_scales_, self.gate_proj_g_idx, None, self.quantize_bit, self.quantize_groupsize
+                )
+                self.down_layer = Ex4bitLinear(
+                    self.down_proj_qweight_, self.down_proj_qzeros_, self.down_proj_scales_, self.down_proj_g_idx, None, self.quantize_bit, self.quantize_groupsize
+                )
+            else:
+                self.q_layer = QuantLinear(
+                    self.q_qweight_, self.q_qzeros_, self.q_scales_, self.q_g_idx, None, self.quantize_bit, self.quantize_groupsize
+                )
+                self.k_layer = QuantLinear(
+                    self.k_qweight_, self.k_qzeros_, self.k_scales_, self.k_g_idx, None, self.quantize_bit, self.quantize_groupsize
+                )
+                self.v_layer = QuantLinear(
+                    self.v_qweight_, self.v_qzeros_, self.v_scales_, self.v_g_idx, None, self.quantize_bit, self.quantize_groupsize
+                )
+                self.o_layer = QuantLinear(
+                    self.o_qweight_, self.o_qzeros_, self.o_scales_, self.o_g_idx, None, self.quantize_bit, self.quantize_groupsize
+                )
+                self.up_layer = QuantLinear(
+                    self.up_proj_qweight_, self.up_proj_qzeros_, self.up_proj_scales_, self.up_proj_g_idx, None, self.quantize_bit, self.quantize_groupsize
+                )
+                self.gate_layer = QuantLinear(
+                    self.gate_proj_qweight_, self.gate_proj_qzeros_, self.gate_proj_scales_, self.gate_proj_g_idx, None, self.quantize_bit, self.quantize_groupsize
+                )
+                self.down_layer = QuantLinear(
+                    self.down_proj_qweight_, self.down_proj_qzeros_, self.down_proj_scales_, self.down_proj_g_idx, None, self.quantize_bit, self.quantize_groupsize
+                )
+                # raise NotImplementedError("`QuantLlama2TransformerLayerWeight` only support exllama-gptq now.")
+        else:
+            raise NotImplementedError("`QuantLlama2TransformerLayerWeight` only support gptq now.")
+
+    def _load_qkvo_dummy_weights(self):
+        global USE_EXLLAMA
+        norm_n_embed = self.network_config_["hidden_size"]
+
+        # input layernorm params
+        self.att_norm_weight_ = (torch.rand((norm_n_embed), dtype=torch.float16, device="cuda") * 2 - 1) * 1e-3
+
+        # attnention params
+        if self.quantize_mode == "gptq":
+            bit, groupsize = self.quantize_bit, self.quantize_groupsize
+
+            qkv_input_embed = norm_n_embed * self.quantize_bit // self.element_size
+            qkv_output_embed = norm_n_embed // self.world_size_
+            qkv_qzeros_input_embed = norm_n_embed // groupsize
+            qkv_qzeros_output_embed = norm_n_embed * self.quantize_bit // self.element_size // self.world_size_
+            qkv_scales_input_embed = qkv_qzeros_input_embed
+            qkv_scales_output_embed = qkv_output_embed
+            
+            o_input_embed = qkv_input_embed // self.world_size_
+            o_output_embed = norm_n_embed
+            o_qzeros_input_embed = norm_n_embed // groupsize // self.world_size_
+            o_qzeros_output_embed = norm_n_embed * self.quantize_bit // self.element_size
+            o_scales_input_embed = o_qzeros_input_embed
+            o_scales_output_embed = o_output_embed
+
+            self.use_exllama = True if (USE_EXLLAMA and bit == 4) else False
+
+            assert (norm_n_embed % groupsize) == 0
+
+            g_idx_range = torch.arange(norm_n_embed // groupsize, dtype=torch.int32)
+            self.q_g_idx = g_idx_range.repeat_interleave(groupsize).cuda()
+            self.k_g_idx = g_idx_range.repeat_interleave(groupsize).cuda()
+            self.v_g_idx = g_idx_range.repeat_interleave(groupsize).cuda()
+            self.o_g_idx = g_idx_range.repeat_interleave(groupsize).cuda()
+
+            self.q_qweight_ = (torch.randint(MIN_INT, MAX_INT, (qkv_input_embed, qkv_output_embed), 
+                                        dtype=self.data_type_, device="cuda"))
+            self.q_qzeros_ = (torch.randint(MIN_INT, MAX_INT, (qkv_qzeros_input_embed, qkv_qzeros_output_embed), 
+                                        dtype=self.data_type_, device="cuda"))
+            self.q_scales_ = (torch.rand((qkv_scales_input_embed, qkv_scales_output_embed), 
+                                        dtype=torch.float16, device="cuda") * 2 - 1) * 1e-3
+            
+            self.k_qweight_ = (torch.randint(MIN_INT, MAX_INT, (qkv_input_embed, qkv_output_embed), 
+                                        dtype=self.data_type_, device="cuda"))
+            self.k_qzeros_ = (torch.randint(MIN_INT, MAX_INT, (qkv_qzeros_input_embed, qkv_qzeros_output_embed), 
+                                        dtype=self.data_type_, device="cuda"))
+            self.k_scales_ = (torch.rand((qkv_scales_input_embed, qkv_scales_output_embed), 
+                                        dtype=torch.float16, device="cuda") * 2 - 1) * 1e-3
+            
+            self.v_qweight_ = (torch.randint(MIN_INT, MAX_INT, (qkv_input_embed, qkv_output_embed), 
+                                        dtype=self.data_type_, device="cuda"))
+            self.v_qzeros_ = (torch.randint(MIN_INT, MAX_INT, (qkv_qzeros_input_embed, qkv_qzeros_output_embed), 
+                                        dtype=self.data_type_, device="cuda"))
+            self.v_scales_ = (torch.rand((qkv_scales_input_embed, qkv_scales_output_embed), 
+                                        dtype=torch.float16, device="cuda") * 2 - 1) * 1e-3
+            # attention output dense params
+            self.o_qweight_ = (torch.randint(MIN_INT, MAX_INT, (o_input_embed, o_output_embed), 
+                                        dtype=self.data_type_, device="cuda"))
+            self.o_qzeros_ = (torch.randint(MIN_INT, MAX_INT, (o_qzeros_input_embed, o_qzeros_output_embed), 
+                                        dtype=self.data_type_, device="cuda"))
+            self.o_scales_ = (torch.rand((o_scales_input_embed, o_scales_output_embed), 
+                                        dtype=torch.float16, device="cuda") * 2 - 1) * 1e-3
+        else:
+            raise NotImplementedError("`QuantLlama2TransformerLayerWeight` only support gptq now.")
+
+    def _load_ffn_dummy_weights(self):
+        norm_n_embed = self.network_config_["hidden_size"]
+
+        self.ffn_norm_weight_ = (torch.rand((norm_n_embed), dtype=torch.float16, device="cuda") * 2 - 1) * 1e-3
+
+        if self.quantize_mode == "gptq":
+            bit, groupsize = self.quantize_bit, self.quantize_groupsize
+            
+            inter_size = self.network_config_["intermediate_size"]
+
+            up_input_embed = norm_n_embed * self.quantize_bit // self.element_size
+            up_output_embed = inter_size // self.world_size_
+            up_qzeros_input_embed = norm_n_embed // groupsize
+            up_qzeros_output_embed = inter_size * self.quantize_bit // self.element_size // self.world_size_
+            up_scales_input_embed = up_qzeros_input_embed
+            up_scales_output_embed = up_output_embed
+
+            down_input_embed = up_qzeros_output_embed
+            down_output_embed = norm_n_embed
+            down_qzeros_input_embed = inter_size // groupsize //self.world_size_
+            down_qzeros_output_embed = norm_n_embed * self.quantize_bit // self.element_size
+            down_scales_input_embed = down_qzeros_input_embed
+            down_scales_output_embed = down_output_embed
+
+            # use_exllama = True if bit == 4 else False
+
+            assert (norm_n_embed % groupsize) == 0
+
+            up_g_idx_range = torch.arange(norm_n_embed // groupsize, dtype=torch.int32)
+            down_g_idx_range = torch.arange(inter_size // groupsize, dtype=torch.int32)
+
+            self.up_proj_g_idx = up_g_idx_range.repeat_interleave(groupsize).cuda()
+            self.gate_proj_g_idx = up_g_idx_range.repeat_interleave(groupsize).cuda()
+            self.down_proj_g_idx = down_g_idx_range.repeat_interleave(groupsize).cuda()
+
+            self.up_proj_qweight_ = (torch.randint(MIN_INT, MAX_INT, (up_input_embed, up_output_embed), 
+                                        dtype=self.data_type_, device="cuda"))
+            self.up_proj_qzeros_ = (torch.randint(MIN_INT, MAX_INT, (up_qzeros_input_embed, up_qzeros_output_embed), 
+                                        dtype=self.data_type_, device="cuda"))
+            self.up_proj_scales_ = (torch.rand((up_scales_input_embed, up_scales_output_embed), 
+                                        dtype=torch.float16, device="cuda") * 2 - 1) * 1e-3
+            
+            self.gate_proj_qweight_ = (torch.randint(MIN_INT, MAX_INT, (up_input_embed, up_output_embed), 
+                                        dtype=self.data_type_, device="cuda"))
+            self.gate_proj_qzeros_ = (torch.randint(MIN_INT, MAX_INT, (up_qzeros_input_embed, up_qzeros_output_embed), 
+                                        dtype=self.data_type_, device="cuda"))
+            self.gate_proj_scales_ = (torch.rand((up_scales_input_embed, up_scales_output_embed), 
+                                        dtype=torch.float16, device="cuda") * 2 - 1) * 1e-3
+            
+            self.down_proj_qweight_ = (torch.randint(MIN_INT, MAX_INT, (down_input_embed, down_output_embed), 
+                                        dtype=self.data_type_, device="cuda"))
+            self.down_proj_qzeros_ = (torch.randint(MIN_INT, MAX_INT, (down_qzeros_input_embed, down_qzeros_output_embed), 
+                                        dtype=self.data_type_, device="cuda"))
+            self.down_proj_scales_ = (torch.rand((down_scales_input_embed, down_scales_output_embed), 
+                                        dtype=torch.float16, device="cuda") * 2 - 1) * 1e-3
+            
+        else:
+            raise NotImplementedError("`QuantLlama2TransformerLayerWeight` only support gptq now.")
+
+    def _load_qkvo_weights(self, weights):
+        global USE_EXLLAMA
+        # input layernorm params
+        if f"model.layers.{self.layer_num_}.input_layernorm.weight" in weights:
+            self.att_norm_weight_ = self._cuda(weights[f"model.layers.{self.layer_num_}.input_layernorm.weight"])
+        
+        if self.quantize_mode == "gptq":
+            bit, groupsize = self.quantize_bit, self.quantize_groupsize
+            self.use_exllama = True if (USE_EXLLAMA and bit == 4) else False
+
+            # if not self.use_exllama:
+            #     raise NotImplementedError("`QuantLlama2TransformerLayerWeight` only support exllama-gptq now.")
+
+            norm_n_embed = self.network_config_["hidden_size"]
+            qkv_input_embed = norm_n_embed * self.quantize_bit // self.element_size
+            qkv_output_embed = norm_n_embed // self.world_size_
+            qkv_qzeros_input_embed = norm_n_embed // groupsize
+            qkv_qzeros_output_embed = norm_n_embed * self.quantize_bit // self.element_size // self.world_size_
+            qkv_scales_input_embed = qkv_qzeros_input_embed
+            qkv_scales_output_embed = qkv_output_embed
+            
+            o_input_embed = qkv_input_embed // self.world_size_
+            o_output_embed = norm_n_embed
+            o_qzeros_input_embed = norm_n_embed // groupsize // self.world_size_
+            o_qzeros_output_embed = norm_n_embed * self.quantize_bit // self.element_size
+            o_scales_input_embed = o_qzeros_input_embed
+            o_scales_output_embed = o_output_embed
+
+            assert (norm_n_embed % groupsize) == 0
+
+            if f"model.layers.{self.layer_num_}.self_attn.o_proj.g_idx" in weights:
+                self.o_g_idx = weights[f"model.layers.{self.layer_num_}.self_attn.o_proj.g_idx"].cuda()
+                # check the o_g_idx is equal to the excepted_g_idx
+                if self.world_size_ > 1:
+                    g_idx_range = torch.arange(norm_n_embed // groupsize, dtype=torch.int32)
+                    excepted_g_idx = g_idx_range.repeat_interleave(groupsize)
+                    equal_flag = (self.o_g_idx == 0).all() or torch.equal(self.o_g_idx.cpu(), excepted_g_idx)
+                    assert equal_flag
+
+                    self.use_exllama = self.use_exllama and equal_flag
+                
+            
+            if f"model.layers.{self.layer_num_}.self_attn.q_proj.g_idx" in weights:
+                self.q_g_idx = weights[f"model.layers.{self.layer_num_}.self_attn.q_proj.g_idx"].cuda()
+            if f"model.layers.{self.layer_num_}.self_attn.k_proj.g_idx" in weights:
+                self.k_g_idx = weights[f"model.layers.{self.layer_num_}.self_attn.k_proj.g_idx"].cuda()
+            if f"model.layers.{self.layer_num_}.self_attn.v_proj.g_idx" in weights:
+                self.v_g_idx = weights[f"model.layers.{self.layer_num_}.self_attn.v_proj.g_idx" ].cuda()
+
+
+            if f"model.layers.{self.layer_num_}.self_attn.q_proj.qweight" in weights:
+                self.q_qweight_ = weights[f"model.layers.{self.layer_num_}.self_attn.q_proj.qweight"][:, qkv_output_embed * self.tp_rank_ : qkv_output_embed * (self.tp_rank_ + 1)].cuda()
+            if f"model.layers.{self.layer_num_}.self_attn.q_proj.qzeros" in weights:
+                self.q_qzeros_ = weights[f"model.layers.{self.layer_num_}.self_attn.q_proj.qzeros"][:, qkv_qzeros_output_embed * self.tp_rank_ : qkv_qzeros_output_embed * (self.tp_rank_ + 1)].cuda()
+            if f"model.layers.{self.layer_num_}.self_attn.q_proj.scales" in weights:
+                self.q_scales_ = weights[f"model.layers.{self.layer_num_}.self_attn.q_proj.scales"][:, qkv_scales_output_embed * self.tp_rank_ : qkv_scales_output_embed * (self.tp_rank_ + 1)].cuda()
+            
+            if f"model.layers.{self.layer_num_}.self_attn.k_proj.qweight" in weights:
+                self.k_qweight_ = weights[f"model.layers.{self.layer_num_}.self_attn.k_proj.qweight"][:, qkv_output_embed * self.tp_rank_ : qkv_output_embed * (self.tp_rank_ + 1)].cuda()
+            if f"model.layers.{self.layer_num_}.self_attn.k_proj.qzeros" in weights:
+                self.k_qzeros_ = weights[f"model.layers.{self.layer_num_}.self_attn.k_proj.qzeros"][:, qkv_qzeros_output_embed * self.tp_rank_ : qkv_qzeros_output_embed * (self.tp_rank_ + 1)].cuda()
+            if f"model.layers.{self.layer_num_}.self_attn.k_proj.scales" in weights:
+                self.k_scales_ = weights[f"model.layers.{self.layer_num_}.self_attn.k_proj.scales"][:, qkv_scales_output_embed * self.tp_rank_ : qkv_scales_output_embed * (self.tp_rank_ + 1)].cuda()
+
+            if f"model.layers.{self.layer_num_}.self_attn.v_proj.qweight" in weights:
+                self.v_qweight_ = weights[f"model.layers.{self.layer_num_}.self_attn.v_proj.qweight"][:, qkv_output_embed * self.tp_rank_ : qkv_output_embed * (self.tp_rank_ + 1)].cuda()
+            if f"model.layers.{self.layer_num_}.self_attn.v_proj.qzeros" in weights:
+                self.v_qzeros_ = weights[f"model.layers.{self.layer_num_}.self_attn.v_proj.qzeros"][:, qkv_qzeros_output_embed * self.tp_rank_ : qkv_qzeros_output_embed * (self.tp_rank_ + 1)].cuda()
+            if f"model.layers.{self.layer_num_}.self_attn.v_proj.scales" in weights:
+                self.v_scales_ = weights[f"model.layers.{self.layer_num_}.self_attn.v_proj.scales"][:, qkv_scales_output_embed * self.tp_rank_ : qkv_scales_output_embed * (self.tp_rank_ + 1)].cuda()
+
+            if f"model.layers.{self.layer_num_}.self_attn.o_proj.qweight" in weights:
+                self.o_qweight_ = weights[f"model.layers.{self.layer_num_}.self_attn.o_proj.qweight"][o_input_embed * self.tp_rank_ : o_input_embed * (self.tp_rank_ + 1), :].cuda()
+            if f"model.layers.{self.layer_num_}.self_attn.o_proj.qzeros" in weights:
+                if groupsize >= 0 or (not self.use_exllama):
+                    self.o_qzeros_ = weights[f"model.layers.{self.layer_num_}.self_attn.o_proj.qzeros"][o_qzeros_input_embed * self.tp_rank_ : o_qzeros_input_embed * (self.tp_rank_ + 1), :].cuda()
+                else:
+                    self.o_qzeros_ = weights[f"model.layers.{self.layer_num_}.self_attn.o_proj.qzeros"].cuda()
+            if f"model.layers.{self.layer_num_}.self_attn.o_proj.scales" in weights:
+                if groupsize >= 0 or (not self.use_exllama):
+                    self.o_scales_ = weights[f"model.layers.{self.layer_num_}.self_attn.o_proj.scales"][o_scales_input_embed * self.tp_rank_ : o_scales_input_embed * (self.tp_rank_ + 1), :].cuda()
+                else:
+                    self.o_scales_ = weights[f"model.layers.{self.layer_num_}.self_attn.o_proj.scales"].cuda()
+
+        else:
+            raise NotImplementedError("`QuantLlama2TransformerLayerWeight` only support gptq now.")
+        
+    def _cuda(self, cpu_tensor):
+        return cpu_tensor.contiguous().to(torch.float16).cuda()
+
+    def _load_ffn_weights(self, weights):
+        if f"model.layers.{self.layer_num_}.post_attention_layernorm.weight" in weights:
+            self.ffn_norm_weight_ = self._cuda(weights[f"model.layers.{self.layer_num_}.post_attention_layernorm.weight"])
+
+        if self.quantize_mode == "gptq":
+            # if not self.use_exllama:
+            #     raise NotImplementedError("`QuantLlama2TransformerLayerWeight` only support exllama-gptq now.")
+            bit, groupsize = self.quantize_bit, self.quantize_groupsize
+
+            inter_size = self.network_config_["intermediate_size"]
+            norm_n_embed = self.network_config_["hidden_size"]
+
+            up_input_embed = norm_n_embed * self.quantize_bit // self.element_size
+            up_output_embed = inter_size // self.world_size_
+            up_qzeros_input_embed = norm_n_embed // groupsize
+            up_qzeros_output_embed = inter_size * self.quantize_bit // self.element_size // self.world_size_
+            up_scales_input_embed = up_qzeros_input_embed
+            up_scales_output_embed = up_output_embed
+
+            down_input_embed = up_qzeros_output_embed
+            down_output_embed = norm_n_embed
+            down_qzeros_input_embed = inter_size // groupsize //self.world_size_
+            down_qzeros_output_embed = norm_n_embed * self.quantize_bit // self.element_size
+            down_scales_input_embed = down_qzeros_input_embed
+            down_scales_output_embed = down_output_embed
+
+            assert (norm_n_embed % groupsize) == 0
+
+            if f"model.layers.{self.layer_num_}.mlp.down_proj.g_idx" in weights:
+                self.down_proj_g_idx = weights[f"model.layers.{self.layer_num_}.mlp.down_proj.g_idx"].cuda()
+                # check the o_g_idx is equal to the excepted_g_idx
+                if self.world_size_ > 1:
+                    g_idx_range = torch.arange(inter_size // groupsize, dtype=torch.int32)
+                    excepted_g_idx = g_idx_range.repeat_interleave(groupsize)
+                    equal_flag = (self.o_g_idx == 0).all() or torch.equal(self.o_g_idx.cpu(), excepted_g_idx)
+                    assert equal_flag
+
+                    self.use_exllama = self.use_exllama and equal_flag
+
+
+            if f"model.layers.{self.layer_num_}.mlp.up_proj.g_idx" in weights:
+                self.up_proj_g_idx = weights[f"model.layers.{self.layer_num_}.mlp.up_proj.g_idx"].cuda()
+            if f"model.layers.{self.layer_num_}.mlp.gate_proj.g_idx" in weights:
+                self.gate_proj_g_idx = weights[f"model.layers.{self.layer_num_}.mlp.gate_proj.g_idx"].cuda()
+            
+            if f"model.layers.{self.layer_num_}.mlp.up_proj.qweight" in weights:
+                self.up_proj_qweight_ = weights[f"model.layers.{self.layer_num_}.mlp.up_proj.qweight"][:, up_output_embed * self.tp_rank_ : up_output_embed * (self.tp_rank_ + 1)].cuda()
+            if f"model.layers.{self.layer_num_}.mlp.up_proj.qzeros" in weights:
+                self.up_proj_qzeros_ = weights[f"model.layers.{self.layer_num_}.mlp.up_proj.qzeros"][:, up_qzeros_output_embed * self.tp_rank_ : up_qzeros_output_embed * (self.tp_rank_ + 1)].cuda()
+            if f"model.layers.{self.layer_num_}.mlp.up_proj.scales" in weights:
+                self.up_proj_scales_ = weights[f"model.layers.{self.layer_num_}.mlp.up_proj.scales"][:, up_scales_output_embed * self.tp_rank_ : up_scales_output_embed * (self.tp_rank_ + 1)].cuda()
+                
+            if f"model.layers.{self.layer_num_}.mlp.gate_proj.qweight" in weights:
+                self.gate_proj_qweight_ = weights[f"model.layers.{self.layer_num_}.mlp.gate_proj.qweight"][:, up_output_embed * self.tp_rank_ : up_output_embed * (self.tp_rank_ + 1)].cuda()
+            if f"model.layers.{self.layer_num_}.mlp.gate_proj.qzeros" in weights:
+                self.gate_proj_qzeros_ = weights[f"model.layers.{self.layer_num_}.mlp.gate_proj.qzeros"][:, up_qzeros_output_embed * self.tp_rank_ : up_qzeros_output_embed * (self.tp_rank_ + 1)].cuda()
+            if f"model.layers.{self.layer_num_}.mlp.gate_proj.scales" in weights:
+                self.gate_proj_scales_ = weights[f"model.layers.{self.layer_num_}.mlp.gate_proj.scales"][:, up_scales_output_embed * self.tp_rank_ : up_scales_output_embed * (self.tp_rank_ + 1)].cuda()
+
+            if f"model.layers.{self.layer_num_}.mlp.down_proj.qweight" in weights:
+                self.down_proj_qweight_ = weights[f"model.layers.{self.layer_num_}.mlp.down_proj.qweight"][down_output_embed * self.tp_rank_ : down_output_embed * (self.tp_rank_ + 1), :].cuda()
+            if f"model.layers.{self.layer_num_}.mlp.down_proj.qzeros" in weights:
+                if groupsize >= 0 or (not self.use_exllama):
+                    self.down_proj_qzeros_ = weights[f"model.layers.{self.layer_num_}.mlp.down_proj.qzeros"][down_qzeros_output_embed * self.tp_rank_ : down_qzeros_output_embed * (self.tp_rank_ + 1), :].cuda()
+                else:
+                    self.down_proj_qzeros_ = weights[f"model.layers.{self.layer_num_}.mlp.down_proj.qzeros"].cuda()
+            if f"model.layers.{self.layer_num_}.mlp.down_proj.scales" in weights:
+                if groupsize >= 0 or (not self.use_exllama):
+                    self.down_proj_scales_ = weights[f"model.layers.{self.layer_num_}.mlp.down_proj.scales"][down_scales_output_embed * self.tp_rank_ : down_scales_output_embed * (self.tp_rank_ + 1), :].cuda()
+                else:
+                    self.down_proj_scales_ = weights[f"model.layers.{self.layer_num_}.mlp.down_proj.scales"].cuda()
+
+        else:
+            raise NotImplementedError("`QuantLlama2TransformerLayerWeight` only support gptq now.")
+        
+"""
+if __name__ == "__main__":
+import torch
+from slora.models.llama2_quant.layer_weights.transformer_layer_weight import QuantLlama2TransformerLayerWeight
+from slora.utils.model_load import hf_load_config, hf_load_quantize_config
+from slora.models.llama2_quant.layer_weights.hf_load_utils import load_hf_quant_weights
+
+weights_dir = "/data1/bak/suilin/codes/llm_weights/Llama-2-7B-Chat-GPTQ/"
+config, _ = hf_load_config(
+    weights_dir, mode="model"
+)
+quantize_config = hf_load_quantize_config(
+    weights_dir
+)
+config["quantize_config"] = quantize_config
+
+layer = QuantLlama2TransformerLayerWeight(
+    0, 0, 1, torch.int32, config, mode=["gptq"]
+)
+
+load_hf_quant_weights(
+    "fp16", "int32", weights_dir, None, [layer], dummy=False
+)
+
+layer.build_quant_layer()
+"""

--- a/slora/models/llama2_quant/model.py
+++ b/slora/models/llama2_quant/model.py
@@ -1,0 +1,97 @@
+import os
+import json
+import torch
+
+from slora.models.llama2_quant.layer_weights.hf_load_utils import load_hf_quant_weights
+from slora.models.llama2_quant.layer_infer.transformer_layer_infer import QuantLlama2TransformerLayerInfer
+from slora.models.llama2_quant.layer_weights.transformer_layer_weight import QuantLlama2TransformerLayerWeight
+
+from slora.mprophet.model_config import get_quantize_config_json
+from slora.utils.model_load import hf_load_quantize_config
+
+from slora.models.llama2.model import Llama2TpPartModel
+
+
+class QuantLlama2TpPartModel(Llama2TpPartModel):
+    # weight class
+    transformer_weight_class = QuantLlama2TransformerLayerWeight
+
+    # infer class
+    transformer_layer_infer_class = QuantLlama2TransformerLayerInfer
+
+    def __init__(self, tp_rank, world_size, weight_dir,
+                 max_total_token_num, mem_adapter_size, load_way="HF", mode=[],
+                 dummy=False):
+        super().__init__(tp_rank, world_size, weight_dir,
+                         max_total_token_num, mem_adapter_size, load_way, mode, dummy=dummy)
+    
+
+    def _init_weights(self):
+        # PS: The weights in `pre_and_post_weight_class` should always have dtype == torch.float16.
+        self.pre_post_weight = self.pre_and_post_weight_class(self.tp_rank_, self.world_size_, torch.float16, network_config=self.config, mode=self.mode)
+        self.trans_layers_weight = [
+            self.transformer_weight_class(i, self.tp_rank_, self.world_size_, torch.int32, network_config=self.config, mode=self.mode)
+            for i in range(self.config["n_layer"])
+        ]
+
+        # TODO: 实现这个函数, 用来为 transformer layer load int32 的 weights
+        load_hf_quant_weights(
+            pre_post_datatype = "fp16",
+            trans_datatype = "int32",
+            weight_dir=self.weight_dir_,
+            pre_post_layer=self.pre_post_weight,
+            transformer_layer_list=self.trans_layers_weight,
+            dummy=self.dummy
+        )
+
+        self.pre_post_weight.verify_load()
+        [weight.verify_load() for weight in self.trans_layers_weight]
+
+        # build quant Linear
+        [weight.build_quant_layer() for weight in self.trans_layers_weight]
+
+    def _init_config(self):
+        super()._init_config()
+        # rename key
+        # repair_config()
+        
+        # load quantize config
+        self._init_quantize_config()
+        return 
+
+    def _init_quantize_config(self):
+        try:
+            from slora.models.gptq.exllama import create_exllama_buffers, set_device
+            HAS_EXLLAMA = True
+            set_device(torch.device(f"cuda:{self.tp_rank_}"))
+            create_exllama_buffers()
+
+        except ImportError:
+            pass
+
+        if self.dummy:
+            self.quantize_config = get_quantize_config_json(self.weight_dir_, self.mode)
+        else:
+            if self.config.get("quantization_config", None) is not None:
+                self.quantize_config = self.config["quantization_config"]
+            else:
+                self.quantize_config = hf_load_quantize_config(self.weight_dir_)
+        
+        # rename keys
+
+        # bind the quantize_config into config TODO: We will delete this line if it's useless
+        self.config["quantize_config"] = self.quantize_config
+        
+        # register some quantize params
+        # TODO: maybe some quantize methods do not have `bits` or `group_size` in the quantize_config
+        self.quantize_bits = self.quantize_config["bits"]
+        self.quantize_groupsize = self.quantize_config["group_size"]
+        
+        # TODO: For simplicity, we assert that we always use 4-bit gptq now. We should support other bits later.
+        assert self.quantize_bits == 4, f"We should only use the 4-bit gptq now, but got `quantize_bits` = {self.quantize_bits}"
+
+        return
+    
+    def _verify_params(self):
+        super()._verify_params()
+        return

--- a/slora/models/peft/lora_unordered_batch_infer_gptq.py
+++ b/slora/models/peft/lora_unordered_batch_infer_gptq.py
@@ -1,0 +1,253 @@
+import numpy as np
+import torch
+import torch.nn as nn
+from typing import final
+
+from slora.models.peft.lora_unordered_batch_infer import LoraUnorderedBatchInfer
+from slora.models.llama.triton_kernel.rotary_emb import rotary_emb_fwd
+from slora.models.peft.triton_kernel.lora.lora_prefill import lora_get_qkvo_fwd_shrink, lora_get_qkvo_fwd_expand
+from slora._kernels import dispatch_bgmv
+
+"""
+This class inherits from `LoraUnorderedBatchInfer` class.
+`LoraUnorderedBatchInferGPTQ` only rewrite some methods to support the forward of quantization layer, e.g. using layer.forward() instead of torch.mm
+"""
+class LoraUnorderedBatchInferGPTQ(LoraUnorderedBatchInfer):
+    def _batch_lora_get_qkv(self, layer_id, input_embs, cache_k, cache_v, infer_state, no_lora_compute=False, no_lora_copy=False)->torch.Tensor:
+        base_model = self.base_model
+        base_layer_weight = base_model.trans_layers_weight[layer_id]
+        base_layer_infer = base_model.layers_infer[layer_id]
+
+        # modified
+        q = base_layer_weight.q_layer(input_embs.view(-1, base_layer_infer.embed_dim_))
+         # @TODO: fix me, filter requests querying only base model
+        assert(len(q)==len(self.req_bins))
+
+        # q (bs, H)
+        if not no_lora_compute:
+            # mark_start("get_q")
+            delta_qA = self.delta[0]
+            dispatch_bgmv(delta_qA, input_embs.view(-1, base_layer_infer.embed_dim_), 
+                          self.key_buffer[layer_id], 
+                          self.infer_adapter.a_start, self.infer_adapter.a_len, 
+                          self.infer_adapter.a_loc, self.req_bins, 0, self.infer_adapter.a_scaling)
+            dispatch_bgmv(q, delta_qA, self.value_buffer[layer_id], self.infer_adapter.a_start, 
+                          self.infer_adapter.a_len, self.infer_adapter.a_loc, 
+                          self.req_bins, 0, self.infer_adapter.a_scaling)
+            # delta_qA = None
+            # mark_end("get_q")
+
+        rotary_emb_fwd(q.view(-1, base_layer_infer.tp_q_head_num_, base_model.head_dim_),
+                          infer_state.position_cos, infer_state.position_sin)
+
+        # modified
+        base_layer_weight.k_layer(
+            input_embs.view(-1, base_layer_infer.embed_dim_), cache = cache_k.view(-1, base_model.tp_k_head_num_ * base_model.head_dim_)
+        )
+
+        # k (bs, H)
+        if not no_lora_compute:
+            # mark_start("get_k")
+            delta_kA = self.delta[1]
+            dispatch_bgmv(delta_kA, input_embs.view(-1, base_layer_infer.embed_dim_), 
+                          self.key_buffer[layer_id], 
+                          self.infer_adapter.a_start, self.infer_adapter.a_len, 
+                          self.infer_adapter.a_loc, self.req_bins, 1, self.infer_adapter.a_scaling)
+            dispatch_bgmv(cache_k.view(-1, base_model.tp_k_head_num_ * base_model.head_dim_), 
+                          delta_kA, self.value_buffer[layer_id], self.infer_adapter.a_start, 
+                          self.infer_adapter.a_len, self.infer_adapter.a_loc, 
+                          self.req_bins, 1, self.infer_adapter.a_scaling)
+            # delta_kA = None
+            # mark_end("get_k")
+
+        rotary_emb_fwd(cache_k, infer_state.position_cos, infer_state.position_sin)
+
+        # modified
+        base_layer_weight.v_layer(
+            input_embs.view(-1, base_layer_infer.embed_dim_), cache = cache_v.view(-1, base_model.tp_k_head_num_ * base_model.head_dim_)
+        )
+
+        # v (bs, H)
+        if not no_lora_compute:
+            # mark_start("get_v")
+            delta_vA = self.delta[2]
+            dispatch_bgmv(delta_vA, input_embs.view(-1, base_layer_infer.embed_dim_), 
+                          self.key_buffer[layer_id], 
+                          self.infer_adapter.a_start, self.infer_adapter.a_len, 
+                          self.infer_adapter.a_loc, self.req_bins, 2, self.infer_adapter.a_scaling)
+            dispatch_bgmv(cache_v.view(-1, base_model.tp_k_head_num_ * base_model.head_dim_), 
+                          delta_vA, self.value_buffer[layer_id], self.infer_adapter.a_start, 
+                          self.infer_adapter.a_len, self.infer_adapter.a_loc, 
+                          self.req_bins, 2, self.infer_adapter.a_scaling)
+            # delta_vA = None
+            # mark_end("get_v")
+
+        return q        
+    
+    def _lora_get_qkv(self, layer_id, input_embs, cache_k, cache_v, infer_state, no_lora_compute=False)->torch.Tensor:
+        base_model = self.base_model
+        base_layer_weight = base_model.trans_layers_weight[layer_id]
+        base_layer_infer = base_model.layers_infer[layer_id]
+
+        # modified
+        q = base_layer_weight.q_layer(input_embs.view(-1, base_layer_infer.embed_dim_))
+        assert(len(q)==len(self.batch_req_bins))
+
+        # q = q_base + input * A * B * scaling
+        # input: (S, H) A: (H, R) B: (R, H)
+        if not no_lora_compute:
+            # fix me: @TODO we need to filter out requests querying only base model
+            delta_qA = self.delta[0]
+            if self.max_b_seq_len >= 200 and self.max_lora_dim >= 64  and len(infer_state.b_seq_len) >= 2:
+            # if 1 == 0:
+                lora_get_qkvo_fwd_shrink(input_embs.view(-1, base_layer_infer.embed_dim_), 
+                                         self.key_buffer[layer_id].view(-1, self.kv_embed_dim), 
+                                         delta_qA, self.infer_adapter.a_loc, self.infer_adapter.a_start, 
+                                         self.infer_adapter.a_len, infer_state.b_start_loc, 
+                                         infer_state.b_seq_len, self.req_bins, base_layer_infer.embed_dim_, 
+                                         0, self.max_lora_dim, self.max_b_seq_len)
+                lora_get_qkvo_fwd_expand(delta_qA, self.value_buffer[layer_id].view(-1, self.kv_embed_dim), 
+                                         q, self.infer_adapter.a_scaling, 
+                                         self.infer_adapter.a_loc, self.infer_adapter.a_start, 
+                                         self.infer_adapter.a_len, infer_state.b_start_loc, 
+                                         infer_state.b_seq_len, self.req_bins, self.kv_embed_dim, 
+                                         0, self.max_lora_dim, self.max_b_seq_len)
+            else:
+                dispatch_bgmv(delta_qA, input_embs.view(-1, base_layer_infer.embed_dim_), 
+                            self.key_buffer[layer_id],
+                            self.infer_adapter.a_start, self.infer_adapter.a_len, 
+                            self.infer_adapter.a_loc, self.batch_req_bins, 0, self.infer_adapter.a_scaling)
+                dispatch_bgmv(q, delta_qA, self.value_buffer[layer_id], self.infer_adapter.a_start, 
+                            self.infer_adapter.a_len, self.infer_adapter.a_loc, 
+                            self.batch_req_bins, 0, self.infer_adapter.a_scaling)
+            # delta_qA = None
+
+        rotary_emb_fwd(q.view(-1, base_layer_infer.tp_q_head_num_, base_model.head_dim_),
+                       infer_state.position_cos, infer_state.position_sin)
+        
+        # modified
+        base_layer_weight.k_layer(
+            input_embs.view(-1, base_layer_infer.embed_dim_), cache = cache_k.view(-1, base_model.tp_k_head_num_ * base_model.head_dim_)
+        )
+
+        # k (S, H)
+        if not no_lora_compute:
+            delta_kA = self.delta[1]
+            if self.max_b_seq_len >= 200 and self.max_lora_dim >= 64  and len(infer_state.b_seq_len) >= 2:
+            # if 1 == 0:
+                lora_get_qkvo_fwd_shrink(input_embs.view(-1, base_layer_infer.embed_dim_), 
+                                         self.key_buffer[layer_id].view(-1, self.kv_embed_dim), 
+                                         delta_kA, self.infer_adapter.a_loc, self.infer_adapter.a_start, 
+                                         self.infer_adapter.a_len, infer_state.b_start_loc, 
+                                         infer_state.b_seq_len, self.req_bins, base_layer_infer.embed_dim_, 
+                                         1, self.max_lora_dim, self.max_b_seq_len)
+                lora_get_qkvo_fwd_expand(delta_kA, self.value_buffer[layer_id].view(-1, self.kv_embed_dim), 
+                                         cache_k.view(-1, base_model.tp_k_head_num_ * base_model.head_dim_), 
+                                         self.infer_adapter.a_scaling, 
+                                         self.infer_adapter.a_loc, self.infer_adapter.a_start, 
+                                         self.infer_adapter.a_len, infer_state.b_start_loc, 
+                                         infer_state.b_seq_len, self.req_bins, self.kv_embed_dim, 
+                                         1, self.max_lora_dim, self.max_b_seq_len)
+            else:
+                dispatch_bgmv(delta_kA, input_embs.view(-1, base_layer_infer.embed_dim_), 
+                            self.key_buffer[layer_id], 
+                            self.infer_adapter.a_start, self.infer_adapter.a_len, 
+                            self.infer_adapter.a_loc, self.batch_req_bins, 1, self.infer_adapter.a_scaling)
+                dispatch_bgmv(cache_k.view(-1, base_model.tp_k_head_num_ * base_model.head_dim_), 
+                            delta_kA, self.value_buffer[layer_id], self.infer_adapter.a_start, 
+                            self.infer_adapter.a_len, self.infer_adapter.a_loc, 
+                            self.batch_req_bins, 1, self.infer_adapter.a_scaling)
+            # delta_kA = None
+
+        rotary_emb_fwd(cache_k, infer_state.position_cos, infer_state.position_sin)
+
+        # modified
+        base_layer_weight.v_layer(
+            input_embs.view(-1, base_layer_infer.embed_dim_), cache = cache_v.view(-1, base_model.tp_k_head_num_ * base_model.head_dim_)
+        )
+
+        # v (S, H)
+        if not no_lora_compute:
+            delta_vA = self.delta[2]
+            if self.max_b_seq_len >= 200 and self.max_lora_dim >= 64 and len(infer_state.b_seq_len) >= 2:
+            # if 1 ==0:
+                lora_get_qkvo_fwd_shrink(input_embs.view(-1, base_layer_infer.embed_dim_), 
+                                         self.key_buffer[layer_id].view(-1, self.kv_embed_dim), 
+                                         delta_vA, self.infer_adapter.a_loc, self.infer_adapter.a_start, 
+                                         self.infer_adapter.a_len, infer_state.b_start_loc, 
+                                         infer_state.b_seq_len, self.req_bins, base_layer_infer.embed_dim_, 
+                                         2, self.max_lora_dim, self.max_b_seq_len)
+                lora_get_qkvo_fwd_expand(delta_vA, self.value_buffer[layer_id].view(-1, self.kv_embed_dim), 
+                                         cache_v.view(-1, base_model.tp_v_head_num_ * base_model.head_dim_), 
+                                         self.infer_adapter.a_scaling, 
+                                         self.infer_adapter.a_loc, self.infer_adapter.a_start, 
+                                         self.infer_adapter.a_len, infer_state.b_start_loc, 
+                                         infer_state.b_seq_len, self.req_bins, self.kv_embed_dim, 
+                                         2, self.max_lora_dim, self.max_b_seq_len)
+            else:
+                dispatch_bgmv(delta_vA, input_embs.view(-1, base_layer_infer.embed_dim_), 
+                            self.key_buffer[layer_id], 
+                            self.infer_adapter.a_start, self.infer_adapter.a_len, 
+                            self.infer_adapter.a_loc, self.batch_req_bins, 2, self.infer_adapter.a_scaling)
+                dispatch_bgmv(cache_v.view(-1, base_model.tp_k_head_num_ * base_model.head_dim_), 
+                            delta_vA, self.value_buffer[layer_id], self.infer_adapter.a_start, 
+                            self.infer_adapter.a_len, self.infer_adapter.a_loc, 
+                            self.batch_req_bins, 2, self.infer_adapter.a_scaling)
+            # delta_vA = None
+        return q
+    
+    def _batch_lora_get_o(self, layer_id, input, infer_state, no_lora_compute=False)->torch.Tensor:
+        base_model = self.base_model
+        base_layer_weight = base_model.trans_layers_weight[layer_id]
+        base_layer_infer = base_model.layers_infer[layer_id]
+        
+        # modified
+        o = base_layer_weight.o_layer(input.view(-1, base_layer_infer.embed_dim_))
+        if not no_lora_compute:
+            # mark_start("get_o")
+            delta_oA = self.delta[0]
+            dispatch_bgmv(delta_oA, input.view(-1, base_layer_infer.embed_dim_), 
+                          self.key_buffer[layer_id], 
+                          self.infer_adapter.a_start, self.infer_adapter.a_len, 
+                          self.infer_adapter.a_loc, self.req_bins, 3, self.infer_adapter.a_scaling)
+            dispatch_bgmv(o, delta_oA, self.value_buffer[layer_id], self.infer_adapter.a_start, 
+                          self.infer_adapter.a_len, self.infer_adapter.a_loc, 
+                          self.req_bins, 3, self.infer_adapter.a_scaling)
+            # delta_oA = None
+            # mark_end("get_o")
+        return o
+
+
+    def _lora_get_o(self, layer_id, input, infer_state, no_lora_compute=False)->torch.Tensor:
+        base_model = self.base_model
+        base_layer_weight = base_model.trans_layers_weight[layer_id]
+        base_layer_infer = base_model.layers_infer[layer_id]
+
+        # modified
+        o = base_layer_weight.o_layer(input.view(-1, base_layer_infer.embed_dim_))
+        if not no_lora_compute:
+            delta_oA = self.delta[0]
+            if self.max_b_seq_len >= 200 and self.max_lora_dim >= 64  and len(infer_state.b_seq_len) >= 2:
+            # if 1 == 0:
+                lora_get_qkvo_fwd_shrink(input.view(-1, base_layer_infer.embed_dim_), 
+                                         self.key_buffer[layer_id].view(-1, self.kv_embed_dim), 
+                                         delta_oA, self.infer_adapter.a_loc, self.infer_adapter.a_start, 
+                                         self.infer_adapter.a_len, infer_state.b_start_loc, 
+                                         infer_state.b_seq_len, self.req_bins, base_layer_infer.embed_dim_, 
+                                         3, self.max_lora_dim, self.max_b_seq_len)
+                lora_get_qkvo_fwd_expand(delta_oA, self.value_buffer[layer_id].view(-1, self.kv_embed_dim), 
+                                         o, self.infer_adapter.a_scaling, 
+                                         self.infer_adapter.a_loc, self.infer_adapter.a_start, 
+                                         self.infer_adapter.a_len, infer_state.b_start_loc, 
+                                         infer_state.b_seq_len, self.req_bins, base_layer_infer.embed_dim_, 
+                                         3, self.max_lora_dim, self.max_b_seq_len)
+            else:
+                dispatch_bgmv(delta_oA, input.view(-1, base_layer_infer.embed_dim_), 
+                            self.key_buffer[layer_id], 
+                            self.infer_adapter.a_start, self.infer_adapter.a_len, 
+                            self.infer_adapter.a_loc, self.batch_req_bins, 3, self.infer_adapter.a_scaling)
+                dispatch_bgmv(o, delta_oA, self.value_buffer[layer_id], self.infer_adapter.a_start, 
+                            self.infer_adapter.a_len, self.infer_adapter.a_loc, 
+                            self.batch_req_bins, 3, self.infer_adapter.a_scaling)
+            # delta_oA = None
+        return o

--- a/slora/mprophet/model_config.py
+++ b/slora/mprophet/model_config.py
@@ -169,3 +169,28 @@ def get_config_json(name):
         raise NotImplementedError
 
     return  config
+
+"""
+Get the quantize config parameter in json forat
+We use the --mode parameter to support 
+"""
+def get_quantize_config_json(name, mode):
+    # Now we only support `gptq` quantization for `llama-2` model
+    if "llama-2" in name.lower():
+        if "gptq" in mode:
+            quantize_config = {
+                "bits": 4,
+                "group_size": 128,
+                "damp_percent": 0.01,
+                "desc_act": False,
+                "sym": True,
+                "true_sequential": True,
+                "model_name_or_path": None,
+                "model_file_base_name": "model"
+            }
+        else:
+            raise NotImplementedError
+    else:
+        raise NotImplementedError
+
+    return quantize_config

--- a/slora/server/router/model_infer/model_rpc.py
+++ b/slora/server/router/model_infer/model_rpc.py
@@ -17,8 +17,10 @@ from slora.server.router.model_infer.infer_batch import InferBatch
 from slora.common.configs.config import setting
 from slora.models.llama.model import LlamaTpPartModel
 from slora.models.llama2.model import Llama2TpPartModel
+from slora.models.llama2_quant.model import QuantLlama2TpPartModel
 from slora.models.peft.lora_adapter import LoraTpPartAdapter
 from slora.models.peft.lora_unordered_batch_infer import LoraUnorderedBatchInfer
+from slora.models.peft.lora_unordered_batch_infer_gptq import LoraUnorderedBatchInferGPTQ
 from slora.models.peft.lora_single_batch_infer import LoraPEFTBatchInfer
 from slora.models.bmm.lora_bmm_infer import LoraBmmInfer
 from slora.server.router.model_infer.infer_adapter import InferAdapter
@@ -27,7 +29,6 @@ from slora.utils.infer_utils import set_random_seed
 from slora.utils.infer_utils import calculate_time, mark_start, mark_end
 from slora.utils.model_utils import get_model_config
 from .post_process import sample
-
 
 class ModelRpcServer(rpyc.Service):
 
@@ -59,11 +60,18 @@ class ModelRpcServer(rpyc.Service):
             self.model_type = model_cfg["model_type"]
             if self.model_type == "llama":
                 if "num_key_value_heads" in model_cfg.keys():
-                    self.model = Llama2TpPartModel(rank_id, world_size, weight_dir,
-                                                    max_total_token_num,
-                                                    mem_adapter_size=input_params.pool_size_lora,
-                                                    load_way=load_way, mode=mode,
-                                                    dummy=input_params.dummy)
+                    if "gptq" in mode:
+                        self.model = QuantLlama2TpPartModel(rank_id, world_size, weight_dir,
+                                                            max_total_token_num,
+                                                            mem_adapter_size=input_params.pool_size_lora,
+                                                            load_way=load_way, mode=mode,
+                                                            dummy=input_params.dummy)
+                    else:
+                        self.model = Llama2TpPartModel(rank_id, world_size, weight_dir,
+                                                        max_total_token_num,
+                                                        mem_adapter_size=input_params.pool_size_lora,
+                                                        load_way=load_way, mode=mode,
+                                                        dummy=input_params.dummy)
                     
                 else:
                     self.model = LlamaTpPartModel(rank_id, world_size, weight_dir,
@@ -214,7 +222,10 @@ class ModelRpcServer(rpyc.Service):
         else:
             adapters = [self.adapters[self.adapter_id[adapter_dir]] for adapter_dir in batch.adapter_dirs]
             if self.input_params.no_lora_compute:
-                engine = LoraUnorderedBatchInfer(self.model, adapters)
+                if "gptq" in self.mode:
+                    engine = LoraUnorderedBatchInferGPTQ(self.model, adapters)
+                else:
+                    engine = LoraUnorderedBatchInfer(self.model, adapters)
             elif self.input_params.bmm:
                 torch.cuda.empty_cache()
                 compressed_dirs = [batch.adapter_dirs[0]]
@@ -230,7 +241,10 @@ class ModelRpcServer(rpyc.Service):
                 adapters = [self.adapters[self.adapter_id[adapter_dir]] for adapter_dir in compressed_dirs]
                 engine = LoraBmmInfer(self.model, adapters, adapter_sep)
             else:
-                engine = LoraUnorderedBatchInfer(self.model, adapters, infer_adapter=self.infer_adapter)
+                if "gptq" in self.mode:
+                    engine = LoraUnorderedBatchInferGPTQ(self.model, adapters, infer_adapter=self.infer_adapter)
+                else:
+                    engine = LoraUnorderedBatchInfer(self.model, adapters, infer_adapter=self.infer_adapter)
             kwargs["no_lora_compute"] = self.input_params.no_lora_compute
             # kwargs["no_lora_copy"] = self.input_params.no_lora_copy 
 

--- a/slora/utils/model_load.py
+++ b/slora/utils/model_load.py
@@ -21,3 +21,16 @@ def hf_load_config(weights_dir, mode="adapter"):
     config_name = "adapter_config.json" if mode == "adapter" else "config.json"
     with open(os.path.join(weights_dir, config_name), "r") as f:
         return json.load(f), weights_dir
+
+def hf_load_quantize_config(weights_dir):
+    # As the weight_dir has already been updated in `hf_load_config` func in `_init_config` func, we assume that the weights_dir is local now.
+    quantize_config_filename = None
+    if os.path.isfile(os.path.join(weights_dir, "quantize_config.json")):
+        quantize_config_filename = os.path.join(weights_dir, "quantize_config.json")
+    elif os.path.isfile(os.path.join(weights_dir, "quant_config.json")):
+        quantize_config_filename = os.path.join(weights_dir, "quant_config.json")
+    else:
+        raise ValueError(f"Can not find either the `quantize_config.json` file or the `quant_config.json` file under the weights_dir `{weights_dir}`. Please check if the model you are using is a quantified model!")
+
+    with open(quantize_config_filename, "r") as f:
+        return json.load(f)


### PR DESCRIPTION
## Introduction to this request
In order to further reduce the resource constraints (e.g. GPU memory & computation resources), I'm working on adding support for quantized LLaMA-2 model at [[here](https://github.com/suilin0432/S-LoRA/tree/develop_quant_llama)](https://github.com/suilin0432/S-LoRA/tree/develop_quant_llama).

I noticed that the TGI(text-generation-inference) framework has good support for GPT-Q quantized LLM models, hence, I borrowed some ideas from TGI to introduce quantized LLM models support into S-LoRA framework.

### Main modifications to Support Quantized LLaMA-2 model
In order to support the GPT-Q Quantized LLaMA-2 model, I make the following main modifications:
1. Add `slora/models/llama2_quant/`: GPT-Q quantized LLaMA-2 model implementations.
2. Add `slora/models/gptq`: Code to support gptq, modified from TGI.
3. Add `slora/models/exllama_kernels`: Code to support gptq-exllama, modified from TGI.
4. Add `slora/models/peft/lora_unordered_batch_infer_gptq.py`: rewrite `_batch_lora_get_qkv`, `_lora_get_qkv`, `_batch_lora_get_o` and `_lora_get_o` functions.
5. Modify `slora/mprophet/model_config.py`: add `get_quantize_config_json` for dummy quantized models.
6. Modify `slora/utils/model_load.py`: add `hf_load_quantize_config` to load quantize config.
7. Modify `slora/server/router/model_infer/model_rpc.py`: add conditional branchs to use `QuantLlama2TpPartModel` and `LoraUnorderedBatchInferGPTQ`.
8. Add `--gptq` in benchmarks/launch_server.py. When we pass `--gptq` to benchmarks/launch_server.py, it will pass `--mode gptq` to slora/server/api_server.py. PS: I use the --mode option to support gptq which is not a advise choice in this version. I'd like to change it to an independent option in the near future.

### How can you use the LLaMA-2 GPTQ model
1. You should download/train the LLaMA-2 GPTQ model, and place it at a suitable place.
2. You should modify configs(BASE_MODEL & LORA_DIR) defined in benchmarks/exp_suite.py
3. When launching the model, you should pass the newly added option to `--model-setting` and pass the `--gptq` option.
4. If you want to use exllama to accelerate the model inference process, you should `cd slora/models/exllama_kernels/ & pip install -v -e .`. When you launch the model you could set `USE_EXLLAMA=True` to enable the exllama.
